### PR TITLE
Fix updateInvoice missing client_id field

### DIFF
--- a/features/invoice/edit/model/updateInvoice.ts
+++ b/features/invoice/edit/model/updateInvoice.ts
@@ -11,7 +11,7 @@ export async function updateInvoice(invoiceId: string, formData: Invoice): Promi
   const res = await supabase
     .from("invoices")
     .update({
-      client: formData.client,
+      client_id: formData.client.id,
       issue_date: issueDate.toISOString().split("T")[0],
       due_date: dueDate.toISOString().split("T")[0],
       status: formData.status,


### PR DESCRIPTION
## Summary
- fix invoice update to store `client_id` instead of entire object

## Testing
- `npm test` *(fails: jest not found)*