### PR TITLE
Add client creation in invoice form

### DIFF
--- a/features/client/create/actions/createClientInline.action.ts
+++ b/features/client/create/actions/createClientInline.action.ts
@@ -1,0 +1,19 @@
+"use server"
+
+import { revalidatePath } from "next/cache"
+import { Client, ClientFormData } from "@/features/client/shared/types/client.types"
+import { createClient } from "@/features/client/create/model/createClient"
+import { Result, fail, success } from "@/shared/utils/result"
+
+export async function createClientInlineAction(data: ClientFormData): Promise<Result<Client>> {
+  try {
+    const { data: client, error } = await createClient(data)
+    if (error || !client) {
+      throw new Error(error?.message || "Erreur lors de la création du client")
+    }
+    revalidatePath("/dashboard/clients")
+    return success(client as Client)
+  } catch (error) {
+    return fail((error as Error).message)
+  }
+}

--- a/features/client/create/hooks/useCreateClientInlineForm.ts
+++ b/features/client/create/hooks/useCreateClientInlineForm.ts
@@ -1,0 +1,52 @@
+import { useState } from "react"
+import { createClientInlineAction } from "@/features/client/create/actions/createClientInline.action"
+import { Client, ClientFormData } from "@/features/client/shared/types/client.types"
+import { ClientFormSchema } from "@/features/client/shared/schema/client.schema"
+
+export function useCreateClientInlineForm(onCreated: (client: Client) => void) {
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const defaultValues: ClientFormSchema = {
+    name: "",
+    email: "",
+    phone: "",
+    hourly_rate: "",
+    billing_address: "",
+    billing_city: "",
+    billing_postal_code: "",
+    billing_country: "",
+    shipping_address: "",
+    shipping_city: "",
+    shipping_postal_code: "",
+    shipping_country: "",
+    notes: "",
+    sameAsShipping: true,
+  }
+
+  async function onSubmit(data: ClientFormSchema) {
+    setIsLoading(true)
+    setError(null)
+    let submitData: ClientFormData = { ...data }
+    if (data.sameAsShipping) {
+      submitData.shipping_address = data.billing_address
+      submitData.shipping_city = data.billing_city
+      submitData.shipping_postal_code = data.billing_postal_code
+      submitData.shipping_country = data.billing_country
+    }
+    try {
+      const result = await createClientInlineAction(submitData)
+      if (result.success) {
+        onCreated(result.data)
+      } else {
+        setError(result.error || "Une erreur est survenue")
+      }
+    } catch (err) {
+      setError("Une erreur est survenue")
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  return { isLoading, error, defaultValues, onSubmit }
+}

--- a/features/client/create/model/createClient.ts
+++ b/features/client/create/model/createClient.ts
@@ -21,5 +21,5 @@ export async function createClient(data: ClientFormData) {
 
   finalData.user_id = user.id;
 
-  return await supabase.from("clients").insert(finalData);
-} 
+  return await supabase.from("clients").insert(finalData).select().single();
+}

--- a/features/invoice/shared/ui/InvoiceForm.tsx
+++ b/features/invoice/shared/ui/InvoiceForm.tsx
@@ -66,6 +66,13 @@ export function InvoiceForm(props: InvoiceFormProps) {
     total,
   } = useInvoiceForm(props)
 
+  const [clients, setClients] = useState(props.clients)
+
+  const handleClientCreated = (client: any) => {
+    setClients((prev) => [...prev, client])
+    form.setValue('client_id', client.id)
+  }
+
   return (
     <FormProvider {...form}>
       <Form {...form}>
@@ -82,7 +89,7 @@ export function InvoiceForm(props: InvoiceFormProps) {
                 <CardTitle>Informations générales</CardTitle>
               </CardHeader>
               <CardContent className="space-y-4">
-                <InvoiceGeneralFields control={control} clients={props.clients} />
+                <InvoiceGeneralFields control={control} clients={clients} onClientCreated={handleClientCreated} />
               </CardContent>
             </Card>
             <Card>

--- a/features/invoice/shared/ui/InvoiceGeneralFields.tsx
+++ b/features/invoice/shared/ui/InvoiceGeneralFields.tsx
@@ -1,9 +1,13 @@
-import React from "react"
+import React, { useState } from "react"
 import { Control, FieldValues, Path } from "react-hook-form"
 import { FormField, FormItem, FormLabel, FormControl, FormMessage } from "@/components/ui/form"
 import { Input } from "@/components/ui/input"
 import { Textarea } from "@/components/ui/textarea"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { Button } from "@/components/ui/button"
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog"
+import { ClientForm } from "@/features/client/shared/ui/ClientForm"
+import { useCreateClientInlineForm } from "@/features/client/create/hooks/useCreateClientInlineForm"
 import { DatePicker } from "@/components/ui/date-picker"
 import { Percent } from "lucide-react"
 
@@ -17,9 +21,16 @@ interface Client {
 type InvoiceGeneralFieldsProps<T extends FieldValues = InvoiceFormValues> = {
   control: Control<T>
   clients: Client[]
+  onClientCreated: (client: Client) => void
 }
 
-export function InvoiceGeneralFields<T extends FieldValues = InvoiceFormValues>({ control, clients }: InvoiceGeneralFieldsProps<T>) {
+export function InvoiceGeneralFields<T extends FieldValues = InvoiceFormValues>({ control, clients, onClientCreated }: InvoiceGeneralFieldsProps<T>) {
+  const [open, setOpen] = useState(false)
+  const { isLoading, error, defaultValues, onSubmit } = useCreateClientInlineForm((client) => {
+    onClientCreated(client)
+    setOpen(false)
+  })
+
   return (
     <>
       <FormField
@@ -43,10 +54,28 @@ export function InvoiceGeneralFields<T extends FieldValues = InvoiceFormValues>(
                 </SelectContent>
               </Select>
             </FormControl>
+            <Button type="button" variant="link" className="p-0 text-sm" onClick={() => setOpen(true)}>
+              Ajouter un client
+            </Button>
             <FormMessage />
           </FormItem>
         )}
       />
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="sm:max-w-lg">
+          <DialogHeader>
+            <DialogTitle>Nouveau client</DialogTitle>
+          </DialogHeader>
+          <ClientForm
+            defaultValues={defaultValues}
+            onSubmit={onSubmit}
+            isLoading={isLoading}
+            error={error}
+            onCancel={() => setOpen(false)}
+            submitLabel="Créer le client"
+          />
+        </DialogContent>
+      </Dialog>
       <div className="grid gap-4 sm:grid-cols-2">
         <FormField
           control={control}


### PR DESCRIPTION
## Summary
- allow returning created client in `createClient`
- add inline client creation action and hook
- display a dialog with `ClientForm` from invoice creation form
- update invoice form to handle new clients on the fly

## Testing
- `npm test` *(fails: jest not found)*