### PR TITLE
Ajout génération PDF factures

### DIFF
--- a/app/api/invoices/[id]/pdf/route.ts
+++ b/app/api/invoices/[id]/pdf/route.ts
@@ -1,0 +1,13 @@
+import { NextRequest } from 'next/server'
+import { generateInvoicePdf } from '@/features/invoice/pdf/model/generateInvoicePdf'
+
+export async function GET(request: NextRequest, { params }: { params: { id: string } }) {
+  const { buffer, invoiceNumber } = await generateInvoicePdf(params.id)
+
+  return new Response(buffer, {
+    headers: {
+      'Content-Type': 'application/pdf',
+      'Content-Disposition': `attachment; filename=${invoiceNumber}.pdf`,
+    },
+  })
+}

--- a/features/invoice/list/ui/InvoicesTableView.tsx
+++ b/features/invoice/list/ui/InvoicesTableView.tsx
@@ -10,7 +10,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
-import { Edit, Eye, MoreHorizontal, Search, Trash } from "lucide-react"
+import { Edit, Eye, MoreHorizontal, Search, Trash, Download } from "lucide-react"
 import {
   AlertDialog,
   AlertDialogAction,
@@ -132,6 +132,16 @@ export function InvoicesTableView({
                               <Edit className="mr-2 h-4 w-4" />
                               Modifier
                             </DropdownMenuItem>
+                            <DropdownMenuItem asChild>
+                              <a
+                                href={`/api/invoices/${invoice.id}/pdf`}
+                                target="_blank"
+                                onClick={(e) => e.stopPropagation()}
+                              >
+                                <Download className="mr-2 h-4 w-4" />
+                                Télécharger PDF
+                              </a>
+                            </DropdownMenuItem>
                             <DropdownMenuSeparator />
                             <DropdownMenuItem
                               className="text-red-600"
@@ -196,6 +206,16 @@ export function InvoicesTableView({
                       >
                         <Edit className="mr-2 h-4 w-4" />
                         Modifier
+                      </DropdownMenuItem>
+                      <DropdownMenuItem asChild>
+                        <a
+                          href={`/api/invoices/${invoice.id}/pdf`}
+                          target="_blank"
+                          onClick={(e) => e.stopPropagation()}
+                        >
+                          <Download className="mr-2 h-4 w-4" />
+                          Télécharger PDF
+                        </a>
                       </DropdownMenuItem>
                       <DropdownMenuSeparator />
                       <DropdownMenuItem

--- a/features/invoice/pdf/actions/downloadInvoicePdf.action.ts
+++ b/features/invoice/pdf/actions/downloadInvoicePdf.action.ts
@@ -1,0 +1,14 @@
+'use server'
+
+import { generateInvoicePdf } from '@/features/invoice/pdf/model/generateInvoicePdf'
+
+export async function downloadInvoicePdfAction(invoiceId: string): Promise<Response> {
+  const { buffer, invoiceNumber } = await generateInvoicePdf(invoiceId)
+
+  return new Response(buffer, {
+    headers: {
+      'Content-Type': 'application/pdf',
+      'Content-Disposition': `attachment; filename=${invoiceNumber}.pdf`,
+    },
+  })
+}

--- a/features/invoice/pdf/index.ts
+++ b/features/invoice/pdf/index.ts
@@ -1,0 +1,2 @@
+export * from './actions/downloadInvoicePdf.action'
+export * from './model/generateInvoicePdf'

--- a/features/invoice/pdf/model/generateInvoicePdf.ts
+++ b/features/invoice/pdf/model/generateInvoicePdf.ts
@@ -1,0 +1,39 @@
+import PDFDocument from 'pdfkit'
+import { getInvoice } from '@/features/invoice/view/model/getInvoice'
+import { getInvoiceItems } from '@/features/invoice/view/model/getInvoiceItems'
+
+export async function generateInvoicePdf(invoiceId: string): Promise<{ buffer: Buffer; invoiceNumber: string }> {
+  const invoice = await getInvoice(invoiceId)
+  const items = await getInvoiceItems(invoiceId)
+
+  const doc = new PDFDocument({ margin: 50 })
+  const chunks: Buffer[] = []
+
+  doc.on('data', (chunk) => chunks.push(chunk))
+
+  const endPromise = new Promise<{ buffer: Buffer; invoiceNumber: string }>((resolve, reject) => {
+    doc.on('end', () => resolve({ buffer: Buffer.concat(chunks), invoiceNumber: invoice.invoice_number }))
+    doc.on('error', reject)
+  })
+
+  doc.fontSize(20).text(`Facture n° ${invoice.invoice_number}`, { align: 'center' })
+  doc.moveDown()
+
+  doc.fontSize(12)
+  doc.text(`Client: ${invoice.client.name}`)
+  doc.text(`Date: ${invoice.issue_date}`)
+  doc.text(`Échéance: ${invoice.due_date}`)
+  doc.moveDown()
+  doc.text('Lignes:')
+  items.forEach((item) => {
+    doc.text(`${item.description} - ${item.quantity} x ${item.unit_price} = ${item.amount}`)
+  })
+  doc.moveDown()
+  doc.text(`Total: ${invoice.total} ${invoice.currency}`)
+  doc.moveDown()
+  doc.text('Mentions légales: ...')
+
+  doc.end()
+
+  return endPromise
+}

--- a/features/invoice/shared/ui/InvoiceDetails.tsx
+++ b/features/invoice/shared/ui/InvoiceDetails.tsx
@@ -171,9 +171,11 @@ export function InvoiceDetails({ invoice, invoiceItems }: InvoiceDetailsProps) {
               Modifier
             </Button>
           </Link>
-          <Button variant="outline">
-            <Download className="mr-2 h-4 w-4" />
-            Télécharger
+          <Button variant="outline" asChild>
+            <a href={`/api/invoices/${invoice.id}/pdf`} target="_blank">
+              <Download className="mr-2 h-4 w-4" />
+              Télécharger PDF
+            </a>
           </Button>
         </div>
         <div className="flex space-x-2">

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "tailwind-merge": "^2.5.5",
     "tailwindcss-animate": "^1.0.7",
     "vaul": "^0.9.6",
+    "pdfkit": "latest",
     "zod": "latest"
   },
   "devDependencies": {


### PR DESCRIPTION
## Notes
- Les tests échouent car `jest` n'est pas installé dans l'environnement.

## Summary
- ajoute `pdfkit` aux dépendances
- création du module `features/invoice/pdf` avec génération de PDF
- route API `/api/invoices/[id]/pdf` pour télécharger le fichier
- ajout du bouton "Télécharger PDF" dans la vue d'une facture et dans la liste
