### PR TITLE
Add invoice email sending feature

### DIFF
--- a/features/invoice/email/actions/sendInvoiceEmail.action.ts
+++ b/features/invoice/email/actions/sendInvoiceEmail.action.ts
@@ -1,0 +1,40 @@
+'use server'
+
+import { getInvoice } from '@/features/invoice/view/model/getInvoice'
+import { generateInvoicePdf } from '@/features/invoice/email/model/generateInvoicePdf'
+import nodemailer from 'nodemailer'
+import { Result, success, fail } from '@/shared/utils/result'
+
+export async function sendInvoiceEmailAction(invoiceId: string, recipientEmail: string): Promise<Result<null>> {
+  try {
+    const invoice = await getInvoice(invoiceId)
+    const pdfBuffer = await generateInvoicePdf(invoiceId)
+
+    const transporter = nodemailer.createTransport({
+      host: process.env.SMTP_HOST,
+      port: Number(process.env.SMTP_PORT || 587),
+      secure: false,
+      auth: {
+        user: process.env.SMTP_USER,
+        pass: process.env.SMTP_PASS,
+      },
+    })
+
+    await transporter.sendMail({
+      from: process.env.EMAIL_FROM,
+      to: recipientEmail,
+      subject: `Facture ${invoice.invoice_number}`,
+      text: `Veuillez trouver votre facture ${invoice.invoice_number} en pièce jointe.`,
+      attachments: [
+        {
+          filename: `facture-${invoice.invoice_number}.pdf`,
+          content: pdfBuffer,
+        },
+      ],
+    })
+
+    return success(null)
+  } catch (error) {
+    return fail((error as Error).message)
+  }
+}

--- a/features/invoice/email/index.ts
+++ b/features/invoice/email/index.ts
@@ -1,0 +1,1 @@
+export { sendInvoiceEmailAction } from './actions/sendInvoiceEmail.action'

--- a/features/invoice/email/model/generateInvoicePdf.ts
+++ b/features/invoice/email/model/generateInvoicePdf.ts
@@ -1,0 +1,8 @@
+'use server'
+
+// TODO: Implement proper PDF generation
+export async function generateInvoicePdf(invoiceId: string): Promise<Buffer> {
+  // Placeholder PDF content
+  const content = `PDF for invoice ${invoiceId}`
+  return Buffer.from(content)
+}

--- a/features/invoice/shared/ui/InvoiceDetails.tsx
+++ b/features/invoice/shared/ui/InvoiceDetails.tsx
@@ -7,7 +7,7 @@ import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/componen
 import { Badge } from "@/components/ui/badge"
 import { Separator } from "@/components/ui/separator"
 import { formatCurrency, formatDate, getInvoiceStatusColor } from "@/shared/lib/utils"
-import { AlertCircle, ArrowLeft, Download, Edit, Send } from "lucide-react"
+import { AlertCircle, ArrowLeft, Download, Edit, Send, Mail } from "lucide-react"
 import { Alert, AlertDescription } from "@/components/ui/alert"
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog"
 import { NewPaymentFormView } from "@/features/payment/create/ui/NewPaymentFormView"
@@ -17,6 +17,8 @@ import { InvoicePaymentsTable } from "@/features/invoice/shared/ui/InvoicePaymen
 import { Invoice, InvoiceDetailsProps } from "@/features/invoice/shared/types/invoice.types"
 import { useRouter } from "next/navigation"
 import PaymentForm from "@/features/payment/shared/ui/PaymentForm"
+import { sendInvoiceEmailAction } from "@/features/invoice/email"
+import { useTransition } from "react"
 
 export function InvoiceDetails({ invoice, invoiceItems }: InvoiceDetailsProps) {
   const router = useRouter()
@@ -29,6 +31,17 @@ export function InvoiceDetails({ invoice, invoiceItems }: InvoiceDetailsProps) {
     updateInvoiceStatus,
     getStatusLabel,
   } = useInvoiceDetails(invoice.id)
+  const [isSending, startSending] = useTransition()
+  const sendEmail = () => {
+    if (!invoice.client.email) return
+    setError(null)
+    startSending(async () => {
+      const res = await sendInvoiceEmailAction(invoice.id, invoice.client.email as string)
+      if (!res.success) {
+        setError(res.error || 'Une erreur est survenue')
+      }
+    })
+  }
 
   // Calculer le total payé
   const totalPaid = invoice.payments.reduce((sum, payment) => sum + payment.amount, 0)
@@ -174,6 +187,10 @@ export function InvoiceDetails({ invoice, invoiceItems }: InvoiceDetailsProps) {
           <Button variant="outline">
             <Download className="mr-2 h-4 w-4" />
             Télécharger
+          </Button>
+          <Button variant="outline" onClick={sendEmail} disabled={isSending || !invoice.client.email}>
+            <Mail className="mr-2 h-4 w-4" />
+            Envoyer par email
           </Button>
         </div>
         <div className="flex space-x-2">

--- a/features/invoice/view/model/getInvoice.ts
+++ b/features/invoice/view/model/getInvoice.ts
@@ -4,12 +4,12 @@ import { getSessionUser } from '@/shared/utils/getSessionUser'
 export async function getInvoice(invoiceId: string): Promise<Invoice> {
   const { supabase, user } = await getSessionUser()
 
- const { data, error } = await supabase
+  const { data, error } = await supabase
     .from('invoices')
     .select(`
       *,
       payments:payments(*),
-      client:client_id(name)
+      client:client_id(name,email)
     `)
     .eq('id', invoiceId)
     .eq('user_id', user.id)

--- a/package.json
+++ b/package.json
@@ -63,7 +63,8 @@
     "tailwind-merge": "^2.5.5",
     "tailwindcss-animate": "^1.0.7",
     "vaul": "^0.9.6",
-    "zod": "latest"
+    "zod": "latest",
+    "nodemailer": "^6.9.11"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.6.3",


### PR DESCRIPTION
## Summary
- support emailing invoices with nodemailer
- expose `sendInvoiceEmailAction` for sending invoice PDFs
- include placeholder PDF generation
- load client email in invoice model
- add email button to invoice details page
- include nodemailer dependency

## Testing
- `npm test` *(fails: jest not found)*