### PR TITLE
Add team management and task assignment

### DIFF
--- a/app/dashboard/projects/[id]/page.tsx
+++ b/app/dashboard/projects/[id]/page.tsx
@@ -1,5 +1,6 @@
 import { getProjectAction } from "@/features/project/shared/actions/getProject.action"
 import { ProjectDetails } from "@/features/project/shared/ui/ProjectDetails"
+import { getTeamMembersAction } from "@/features/team/list/actions/getTeamMembers.action"
 import { notFound, redirect } from "next/navigation"
 
 export default async function ProjectPage({
@@ -8,6 +9,7 @@ export default async function ProjectPage({
   params: { id: string }
 }) {
   const result = await getProjectAction(params.id)
+  const teamResult = await getTeamMembersAction()
 
   if (!result.success) {
     if (result.error === "Non authentifié") {
@@ -16,9 +18,12 @@ export default async function ProjectPage({
     notFound()
   }
 
+  const teamMembers = teamResult.success ? teamResult.data : []
+
   return (
     <ProjectDetails
       project={result.data}
+      teamMembers={teamMembers}
     />
   )
 }

--- a/app/dashboard/team/[id]/page.tsx
+++ b/app/dashboard/team/[id]/page.tsx
@@ -1,0 +1,20 @@
+import { TeamMemberForm } from '@/features/team/shared/ui/TeamMemberForm'
+import { getTeamMemberAction } from '@/features/team/shared/actions/getTeamMember.action'
+
+export default async function EditTeamMemberPage({ params }: { params: { id: string } }) {
+  const result = await getTeamMemberAction(params.id)
+
+  if (!result.success) {
+    return <div>{result.error}</div>
+  }
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div>
+        <h1 className="text-3xl font-bold tracking-tight">Modifier le membre</h1>
+        <p className="text-muted-foreground">Mettre à jour les informations du membre</p>
+      </div>
+      <TeamMemberForm member={result.data} />
+    </div>
+  )
+}

--- a/app/dashboard/team/new/page.tsx
+++ b/app/dashboard/team/new/page.tsx
@@ -1,0 +1,13 @@
+import { TeamMemberForm } from '@/features/team/shared/ui/TeamMemberForm'
+
+export default async function NewTeamMemberPage() {
+  return (
+    <div className="flex flex-col gap-6">
+      <div>
+        <h1 className="text-3xl font-bold tracking-tight">Nouveau membre</h1>
+        <p className="text-muted-foreground">Ajoutez un membre à votre équipe</p>
+      </div>
+      <TeamMemberForm member={null} />
+    </div>
+  )
+}

--- a/app/dashboard/team/page.tsx
+++ b/app/dashboard/team/page.tsx
@@ -1,0 +1,31 @@
+import { TeamMembersTable } from '@/features/team/list/ui/TeamMembersTable'
+import { getTeamMembersAction } from '@/features/team/list/actions/getTeamMembers.action'
+import { Button } from '@/components/ui/button'
+import Link from 'next/link'
+import { Plus } from 'lucide-react'
+
+export default async function TeamPage() {
+  const result = await getTeamMembersAction()
+
+  if (!result.success) {
+    return <div>Error: {result.error}</div>
+  }
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-3xl font-bold tracking-tight">Équipe</h1>
+          <p className="text-muted-foreground">Gérez les membres de votre équipe</p>
+        </div>
+        <Link href="/dashboard/team/new">
+          <Button>
+            <Plus className="mr-2 h-4 w-4" />
+            Nouveau membre
+          </Button>
+        </Link>
+      </div>
+      <TeamMembersTable members={result.data} />
+    </div>
+  )
+}

--- a/features/project/shared/ui/ProjectDetails.tsx
+++ b/features/project/shared/ui/ProjectDetails.tsx
@@ -4,12 +4,14 @@ import { useProjectDetails } from "@/features/project/shared/hooks/useProjectDet
 import { ProjectDetailsView } from "@/features/project/shared/ui/ProjectDetailsView"
 import { Task } from "@/features/task/shared/types/task.types"
 import { Project } from "@/features/project/shared/types/project.types"
+import { TeamMember } from "@/features/team/shared/types/team.types"
 
-export function ProjectDetails({ project}: { project: Project}) {
+export function ProjectDetails({ project, teamMembers }: { project: Project; teamMembers: TeamMember[] }) {
   const details = useProjectDetails(project)
   return (
     <ProjectDetailsView
       project={project}
+      teamMembers={teamMembers}
       {...details}
     />
   )

--- a/features/project/shared/ui/ProjectDetailsView.tsx
+++ b/features/project/shared/ui/ProjectDetailsView.tsx
@@ -8,6 +8,7 @@ import { ArrowLeft, Edit, Plus, Filter } from "lucide-react"
 import Link from "next/link"
 import { TaskList } from "@/features/task/shared/ui/TaskList"
 import { TaskForm } from "@/features/task/shared/ui/TaskForm"
+import { TeamMember } from "@/features/team/shared/types/team.types"
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog"
 import { Alert, AlertDescription } from "@/components/ui/alert"
 import { AlertCircle } from "lucide-react"
@@ -40,6 +41,7 @@ interface ProjectDetailsViewProps {
   getStatusLabel: (s: string) => string
   getStatusBadgeClass: (s: string) => string
   getTaskStatusLabel: (s: string) => string
+  teamMembers: TeamMember[]
   router: any
 }
 
@@ -60,6 +62,7 @@ export const ProjectDetailsView: React.FC<ProjectDetailsViewProps> = ({
   getStatusLabel,
   getStatusBadgeClass,
   getTaskStatusLabel,
+  teamMembers,
   router,
 }) => (
   <div className="space-y-6">
@@ -222,6 +225,7 @@ export const ProjectDetailsView: React.FC<ProjectDetailsViewProps> = ({
                 <TaskForm
                   projectId={project.id}
                   task={null as unknown as Task}
+                  teamMembers={teamMembers}
                   onSuccess={() => {
                     setTaskDialogOpen(false)
                     router.refresh()
@@ -236,6 +240,7 @@ export const ProjectDetailsView: React.FC<ProjectDetailsViewProps> = ({
       <TabsContent value="tasks" className="space-y-4">
         <TaskList
           tasks={filteredTasks}
+          teamMembers={teamMembers}
           onTaskUpdate={() => router.refresh()}
           onTaskDelete={() => router.refresh()}
         />

--- a/features/task/shared/ui/TaskForm.tsx
+++ b/features/task/shared/ui/TaskForm.tsx
@@ -5,9 +5,10 @@ import type React from "react"
 import { Task } from "@/features/task/shared/types/task.types"
 import { useTaskForm } from "@/features/task/shared/hooks/useTaskForm"
 import { TaskFormView } from "@/features/task/shared/ui/TaskFormView"
+import { TeamMember } from "@/features/team/shared/types/team.types"
 
 
-export function TaskForm({ projectId, task, onSuccess }: { projectId: string, task: Task, onSuccess: () => void }) {
+export function TaskForm({ projectId, task, teamMembers, onSuccess }: { projectId: string; task: Task; teamMembers: TeamMember[]; onSuccess: () => void }) {
   const {
     formData,
     handleChange,
@@ -23,6 +24,7 @@ export function TaskForm({ projectId, task, onSuccess }: { projectId: string, ta
       onSubmit={handleSubmit}
       isLoading={isLoading}
       error={error}
+      teamMembers={teamMembers}
       isEdit={!!task}
     />
   )

--- a/features/task/shared/ui/TaskFormView.tsx
+++ b/features/task/shared/ui/TaskFormView.tsx
@@ -23,6 +23,7 @@ interface TaskFormViewProps {
   isLoading: boolean
   error: string | null
   isEdit?: boolean
+  teamMembers: { id: string; name: string }[]
 }
 
 export function TaskFormView({
@@ -32,6 +33,7 @@ export function TaskFormView({
   isLoading,
   error,
   isEdit = false,
+  teamMembers,
 }: TaskFormViewProps) {
   return (
     <form onSubmit={onSubmit} className="space-y-4">
@@ -99,7 +101,9 @@ export function TaskFormView({
           </SelectTrigger>
           <SelectContent>
             <SelectItem value="unassigned">Non assignée</SelectItem>
-            {/* TODO: teamMembers logic to be handled separately */}
+            {teamMembers.map((member) => (
+              <SelectItem key={member.id} value={member.id}>{member.name}</SelectItem>
+            ))}
           </SelectContent>
         </Select>
       </div>

--- a/features/task/shared/ui/TaskList.tsx
+++ b/features/task/shared/ui/TaskList.tsx
@@ -21,9 +21,10 @@ import { TaskForm } from "@/features/task/shared/ui/TaskForm"
 import { Avatar, AvatarFallback } from "@/components/ui/avatar"
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip"
 import { Task } from "@/features/task/shared/types/task.types"
+import { TeamMember } from "@/features/team/shared/types/team.types"
 
 
-export function TaskList({ tasks, onTaskUpdate, onTaskDelete }: { tasks: Task[], onTaskUpdate: () => void, onTaskDelete: () => void }) {
+export function TaskList({ tasks, teamMembers, onTaskUpdate, onTaskDelete }: { tasks: Task[]; teamMembers: TeamMember[]; onTaskUpdate: () => void; onTaskDelete: () => void }) {
   const supabase = createClient()
   const [editTask, setEditTask] = useState<Task | null>(null)
   const [deleteTask, setDeleteTask] = useState<Task | null>(null)
@@ -240,6 +241,7 @@ export function TaskList({ tasks, onTaskUpdate, onTaskDelete }: { tasks: Task[],
                             <TaskForm
                               projectId={task.project_id}
                               task={task}
+                              teamMembers={teamMembers}
                               onSuccess={() => {
                                 setEditTask(null)
                                 if (onTaskUpdate) onTaskUpdate()

--- a/features/team/create/actions/createTeamMember.action.ts
+++ b/features/team/create/actions/createTeamMember.action.ts
@@ -1,0 +1,14 @@
+"use server"
+
+import { createTeamMember } from '@/features/team/create/model/createTeamMember'
+import { TeamMember, TeamMemberFormData } from '@/features/team/shared/types/team.types'
+import { fail, Result, success } from '@/shared/utils/result'
+
+export async function createTeamMemberAction(data: TeamMemberFormData): Promise<Result<TeamMember>> {
+  try {
+    const member = await createTeamMember(data)
+    return success(member)
+  } catch (error) {
+    return fail((error as Error).message)
+  }
+}

--- a/features/team/create/model/createTeamMember.ts
+++ b/features/team/create/model/createTeamMember.ts
@@ -1,0 +1,15 @@
+import { getSessionUser } from '@/shared/utils/getSessionUser'
+import { extractDataOrThrow } from '@/shared/utils/extractDataOrThrow'
+import { TeamMember, TeamMemberFormData } from '@/features/team/shared/types/team.types'
+
+export async function createTeamMember(data: TeamMemberFormData): Promise<TeamMember> {
+  const { supabase, user } = await getSessionUser()
+
+  const res = await supabase
+    .from('team_members')
+    .insert({ ...data, user_id: user.id })
+    .select('*')
+    .single()
+
+  return extractDataOrThrow<TeamMember>(res)
+}

--- a/features/team/delete/actions/deleteTeamMember.action.ts
+++ b/features/team/delete/actions/deleteTeamMember.action.ts
@@ -1,0 +1,14 @@
+"use server"
+
+import { deleteTeamMember } from '@/features/team/delete/model/deleteTeamMember'
+import { TeamMember } from '@/features/team/shared/types/team.types'
+import { fail, Result, success } from '@/shared/utils/result'
+
+export async function deleteTeamMemberAction(id: string): Promise<Result<TeamMember>> {
+  try {
+    const member = await deleteTeamMember(id)
+    return success(member)
+  } catch (error) {
+    return fail((error as Error).message)
+  }
+}

--- a/features/team/delete/model/deleteTeamMember.ts
+++ b/features/team/delete/model/deleteTeamMember.ts
@@ -1,0 +1,17 @@
+import { getSessionUser } from '@/shared/utils/getSessionUser'
+import { extractDataOrThrow } from '@/shared/utils/extractDataOrThrow'
+import { TeamMember } from '@/features/team/shared/types/team.types'
+
+export async function deleteTeamMember(id: string): Promise<TeamMember> {
+  const { supabase, user } = await getSessionUser()
+
+  const res = await supabase
+    .from('team_members')
+    .delete()
+    .eq('id', id)
+    .eq('user_id', user.id)
+    .select('*')
+    .single()
+
+  return extractDataOrThrow<TeamMember>(res)
+}

--- a/features/team/edit/actions/updateTeamMember.action.ts
+++ b/features/team/edit/actions/updateTeamMember.action.ts
@@ -1,0 +1,14 @@
+"use server"
+
+import { updateTeamMember } from '@/features/team/edit/model/updateTeamMember'
+import { TeamMember, TeamMemberFormData } from '@/features/team/shared/types/team.types'
+import { fail, Result, success } from '@/shared/utils/result'
+
+export async function updateTeamMemberAction(id: string, data: TeamMemberFormData): Promise<Result<TeamMember>> {
+  try {
+    const member = await updateTeamMember(id, data)
+    return success(member)
+  } catch (error) {
+    return fail((error as Error).message)
+  }
+}

--- a/features/team/edit/model/updateTeamMember.ts
+++ b/features/team/edit/model/updateTeamMember.ts
@@ -1,0 +1,17 @@
+import { getSessionUser } from '@/shared/utils/getSessionUser'
+import { extractDataOrThrow } from '@/shared/utils/extractDataOrThrow'
+import { TeamMember, TeamMemberFormData } from '@/features/team/shared/types/team.types'
+
+export async function updateTeamMember(id: string, data: TeamMemberFormData): Promise<TeamMember> {
+  const { supabase, user } = await getSessionUser()
+
+  const res = await supabase
+    .from('team_members')
+    .update(data)
+    .eq('id', id)
+    .eq('user_id', user.id)
+    .select('*')
+    .single()
+
+  return extractDataOrThrow<TeamMember>(res)
+}

--- a/features/team/list/actions/getTeamMembers.action.ts
+++ b/features/team/list/actions/getTeamMembers.action.ts
@@ -1,0 +1,14 @@
+"use server"
+
+import { getTeamMembers } from '@/features/team/shared/model/getTeamMembers'
+import { TeamMember } from '@/features/team/shared/types/team.types'
+import { fail, Result, success } from '@/shared/utils/result'
+
+export async function getTeamMembersAction(): Promise<Result<TeamMember[]>> {
+  try {
+    const members = await getTeamMembers()
+    return success(members)
+  } catch (error) {
+    return fail((error as Error).message)
+  }
+}

--- a/features/team/list/hooks/useTeamMembersTable.ts
+++ b/features/team/list/hooks/useTeamMembersTable.ts
@@ -1,0 +1,30 @@
+import { useRouter } from 'next/navigation'
+import { useState } from 'react'
+import { deleteTeamMemberAction } from '@/features/team/delete/actions/deleteTeamMember.action'
+import { TeamMember } from '@/features/team/shared/types/team.types'
+
+export function useTeamMembersTable(members: TeamMember[]) {
+  const router = useRouter()
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
+  const [memberToDelete, setMemberToDelete] = useState<string | null>(null)
+
+  const handleDelete = async () => {
+    if (!memberToDelete) return
+    const result = await deleteTeamMemberAction(memberToDelete)
+    if (result.success) {
+      router.refresh()
+    }
+    setDeleteDialogOpen(false)
+    setMemberToDelete(null)
+  }
+
+  return {
+    members,
+    deleteDialogOpen,
+    setDeleteDialogOpen,
+    memberToDelete,
+    setMemberToDelete,
+    handleDelete,
+    router,
+  }
+}

--- a/features/team/list/ui/TeamMembersTable.tsx
+++ b/features/team/list/ui/TeamMembersTable.tsx
@@ -1,0 +1,10 @@
+"use client"
+
+import { TeamMember } from '@/features/team/shared/types/team.types'
+import { useTeamMembersTable } from '@/features/team/list/hooks/useTeamMembersTable'
+import { TeamMembersTableView } from '@/features/team/list/ui/TeamMembersTableView'
+
+export function TeamMembersTable({ members }: { members: TeamMember[] }) {
+  const props = useTeamMembersTable(members)
+  return <TeamMembersTableView {...props} />
+}

--- a/features/team/list/ui/TeamMembersTableView.tsx
+++ b/features/team/list/ui/TeamMembersTableView.tsx
@@ -1,0 +1,73 @@
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table'
+import { Button } from '@/components/ui/button'
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdown-menu'
+import { MoreHorizontal, Edit, Trash } from 'lucide-react'
+import Link from 'next/link'
+import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle } from '@/components/ui/alert-dialog'
+import { TeamMember } from '@/features/team/shared/types/team.types'
+
+interface TeamMembersTableViewProps {
+  members: TeamMember[]
+  deleteDialogOpen: boolean
+  setDeleteDialogOpen: (b: boolean) => void
+  memberToDelete: string | null
+  setMemberToDelete: (id: string | null) => void
+  handleDelete: () => void
+  router: any
+}
+
+export function TeamMembersTableView({ members, deleteDialogOpen, setDeleteDialogOpen, memberToDelete, setMemberToDelete, handleDelete, router }: TeamMembersTableViewProps) {
+  return (
+    <div className="overflow-x-auto">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Nom</TableHead>
+            <TableHead>Email</TableHead>
+            <TableHead>Rôle</TableHead>
+            <TableHead className="w-1"></TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {members.map((member) => (
+            <TableRow key={member.id}>
+              <TableCell>{member.name}</TableCell>
+              <TableCell>{member.email}</TableCell>
+              <TableCell>{member.role}</TableCell>
+              <TableCell className="text-right">
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button variant="ghost" size="icon">
+                      <MoreHorizontal className="h-4 w-4" />
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end">
+                    <DropdownMenuItem onClick={() => router.push(`/dashboard/team/${member.id}`)}>
+                      <Edit className="mr-2 h-4 w-4" /> Modifier
+                    </DropdownMenuItem>
+                    <DropdownMenuItem onClick={() => { setMemberToDelete(member.id); setDeleteDialogOpen(true); }} className="text-red-600">
+                      <Trash className="mr-2 h-4 w-4" /> Supprimer
+                    </DropdownMenuItem>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+      <AlertDialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Confirmer la suppression</AlertDialogTitle>
+          </AlertDialogHeader>
+          <AlertDialogFooter className="flex-col sm:flex-row gap-2">
+            <AlertDialogCancel>Annuler</AlertDialogCancel>
+            <AlertDialogAction onClick={handleDelete} className="bg-red-600 hover:bg-red-700">
+              Supprimer
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  )
+}

--- a/features/team/shared/actions/getTeamMember.action.ts
+++ b/features/team/shared/actions/getTeamMember.action.ts
@@ -1,0 +1,14 @@
+"use server"
+
+import { getTeamMember } from '@/features/team/shared/model/getTeamMember'
+import { TeamMember } from '@/features/team/shared/types/team.types'
+import { fail, Result, success } from '@/shared/utils/result'
+
+export async function getTeamMemberAction(id: string): Promise<Result<TeamMember>> {
+  try {
+    const member = await getTeamMember(id)
+    return success(member)
+  } catch (error) {
+    return fail((error as Error).message)
+  }
+}

--- a/features/team/shared/hooks/useTeamMemberForm.ts
+++ b/features/team/shared/hooks/useTeamMemberForm.ts
@@ -1,0 +1,46 @@
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { TeamMember } from '@/features/team/shared/types/team.types'
+import { teamMemberFormSchema, TeamMemberFormSchema } from '@/features/team/shared/schema/teamMember.schema'
+import { createTeamMemberAction } from '@/features/team/create/actions/createTeamMember.action'
+import { updateTeamMemberAction } from '@/features/team/edit/actions/updateTeamMember.action'
+
+export function useTeamMemberForm(member: TeamMember | null) {
+  const router = useRouter()
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const form = useForm<TeamMemberFormSchema>({
+    resolver: zodResolver(teamMemberFormSchema),
+    defaultValues: {
+      name: member?.name || '',
+      email: member?.email || '',
+      role: member?.role || '',
+    },
+  })
+
+  const onSubmit = async (values: TeamMemberFormSchema) => {
+    setIsLoading(true)
+    setError(null)
+    try {
+      const result = member
+        ? await updateTeamMemberAction(member.id, values)
+        : await createTeamMemberAction(values)
+      if (!result.success) {
+        setError(result.error || 'Erreur inconnue')
+        setIsLoading(false)
+        return
+      }
+      router.push('/dashboard/team')
+      router.refresh()
+    } catch (err: any) {
+      setError(err.message || 'Erreur inconnue')
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  return { form, onSubmit, isLoading, error }
+}

--- a/features/team/shared/model/getTeamMember.ts
+++ b/features/team/shared/model/getTeamMember.ts
@@ -1,0 +1,16 @@
+import { getSessionUser } from '@/shared/utils/getSessionUser'
+import { extractDataOrThrow } from '@/shared/utils/extractDataOrThrow'
+import { TeamMember } from '@/features/team/shared/types/team.types'
+
+export async function getTeamMember(id: string): Promise<TeamMember> {
+  const { supabase, user } = await getSessionUser()
+
+  const res = await supabase
+    .from('team_members')
+    .select('*')
+    .eq('id', id)
+    .eq('user_id', user.id)
+    .single()
+
+  return extractDataOrThrow<TeamMember>(res)
+}

--- a/features/team/shared/model/getTeamMembers.ts
+++ b/features/team/shared/model/getTeamMembers.ts
@@ -1,0 +1,15 @@
+import { getSessionUser } from '@/shared/utils/getSessionUser'
+import { extractDataOrThrow } from '@/shared/utils/extractDataOrThrow'
+import { TeamMember } from '@/features/team/shared/types/team.types'
+
+export async function getTeamMembers(): Promise<TeamMember[]> {
+  const { supabase, user } = await getSessionUser()
+
+  const res = await supabase
+    .from('team_members')
+    .select('*')
+    .eq('user_id', user.id)
+    .order('name', { ascending: true })
+
+  return extractDataOrThrow<TeamMember[]>(res)
+}

--- a/features/team/shared/schema/teamMember.schema.ts
+++ b/features/team/shared/schema/teamMember.schema.ts
@@ -1,0 +1,9 @@
+import { z } from "zod"
+
+export const teamMemberFormSchema = z.object({
+  name: z.string().min(1, "Le nom est requis"),
+  email: z.string().email("Email invalide"),
+  role: z.string().optional(),
+})
+
+export type TeamMemberFormSchema = z.infer<typeof teamMemberFormSchema>

--- a/features/team/shared/types/team.types.ts
+++ b/features/team/shared/types/team.types.ts
@@ -1,0 +1,15 @@
+export interface TeamMember {
+  id: string;
+  user_id?: string;
+  name: string;
+  email: string;
+  role?: string;
+  created_at?: string;
+  updated_at?: string;
+}
+
+export interface TeamMemberFormData {
+  name: string;
+  email: string;
+  role?: string;
+}

--- a/features/team/shared/ui/TeamMemberForm.tsx
+++ b/features/team/shared/ui/TeamMemberForm.tsx
@@ -1,0 +1,18 @@
+"use client"
+
+import { TeamMember } from '@/features/team/shared/types/team.types'
+import { TeamMemberFormView } from '@/features/team/shared/ui/TeamMemberFormView'
+import { useTeamMemberForm } from '@/features/team/shared/hooks/useTeamMemberForm'
+
+export function TeamMemberForm({ member }: { member: TeamMember | null }) {
+  const { form, onSubmit, isLoading, error } = useTeamMemberForm(member)
+
+  return (
+    <TeamMemberFormView
+      form={form}
+      onSubmit={onSubmit}
+      isLoading={isLoading}
+      error={error}
+    />
+  )
+}

--- a/features/team/shared/ui/TeamMemberFormView.tsx
+++ b/features/team/shared/ui/TeamMemberFormView.tsx
@@ -1,0 +1,72 @@
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Alert, AlertDescription } from '@/components/ui/alert'
+import { AlertCircle, Loader2 } from 'lucide-react'
+import { Form, FormField, FormItem, FormLabel, FormControl, FormMessage } from '@/components/ui/form'
+import { UseFormReturn } from 'react-hook-form'
+import { TeamMemberFormSchema } from '@/features/team/shared/schema/teamMember.schema'
+
+interface TeamMemberFormViewProps {
+  form: UseFormReturn<TeamMemberFormSchema>
+  isLoading: boolean
+  error: string | null
+  onSubmit: (values: TeamMemberFormSchema) => void
+}
+
+export function TeamMemberFormView({ form, isLoading, error, onSubmit }: TeamMemberFormViewProps) {
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+        {error && (
+          <Alert variant="destructive">
+            <AlertCircle className="h-4 w-4" />
+            <AlertDescription>{error}</AlertDescription>
+          </Alert>
+        )}
+        <FormField
+          control={form.control}
+          name="name"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Nom</FormLabel>
+              <FormControl>
+                <Input {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="email"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Email</FormLabel>
+              <FormControl>
+                <Input type="email" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="role"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Rôle</FormLabel>
+              <FormControl>
+                <Input {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <Button type="submit" disabled={isLoading} className="w-full sm:w-auto">
+          {isLoading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+          Enregistrer
+        </Button>
+      </form>
+    </Form>
+  )
+}


### PR DESCRIPTION
## Summary
- add CRUD actions and pages for team members
- fetch team members server-side for project pages
- pass team members to task forms and lists
- populate assignment dropdown from team member list

## Testing
- `npm test` *(fails: jest not found)*