### PR TITLE
Add Stripe checkout integration

### DIFF
--- a/app/api/stripe/webhook/route.ts
+++ b/app/api/stripe/webhook/route.ts
@@ -1,0 +1,50 @@
+import { NextRequest } from 'next/server'
+import Stripe from 'stripe'
+import { createClient } from '@/shared/lib/supabase/server'
+import { extractDataOrThrow } from '@/shared/utils/extractDataOrThrow'
+import { Invoice } from '@/features/invoice/shared/types/invoice.types'
+
+export async function POST(req: NextRequest) {
+  const body = await req.text()
+  const signature = req.headers.get('stripe-signature') as string
+
+  const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, { apiVersion: '2024-04-10' })
+
+  let event: Stripe.Event
+  try {
+    event = stripe.webhooks.constructEvent(body, signature, process.env.STRIPE_WEBHOOK_SECRET!)
+  } catch (err) {
+    return new Response(`Webhook Error: ${(err as Error).message}`, { status: 400 })
+  }
+
+  if (event.type === 'checkout.session.completed') {
+    const session = event.data.object as Stripe.Checkout.Session
+    const invoiceId = session.metadata?.invoice_id
+
+    if (invoiceId) {
+      const supabase = await createClient()
+      const res = await supabase
+        .from('invoices')
+        .select('*')
+        .eq('id', invoiceId)
+        .single()
+      const invoice = extractDataOrThrow<Invoice>(res)
+
+      await supabase.from('payments').insert({
+        invoice_id: invoiceId,
+        amount: (session.amount_total || 0) / 100,
+        payment_date: new Date().toISOString().split('T')[0],
+        payment_method: 'stripe',
+        notes: 'Stripe Checkout',
+      })
+
+      const { data: sumData } = await supabase.rpc('sum_payments_by_invoice', { invoiceid: invoiceId })
+      const totalPaid = sumData ?? 0
+      if (totalPaid >= Number(invoice.total)) {
+        await supabase.from('invoices').update({ status: 'paid' }).eq('id', invoiceId)
+      }
+    }
+  }
+
+  return new Response(null, { status: 200 })
+}

--- a/features/payment/create/actions/createPayment.action.ts
+++ b/features/payment/create/actions/createPayment.action.ts
@@ -1,15 +1,55 @@
 'use server'
 
 import { revalidatePath } from 'next/cache'
+import Stripe from 'stripe'
 import { PaymentFormData } from '@/features/payment/shared/types/payment.types'
 import { createPayment } from '@/features/payment/create/model/createPayment'
+import { getSessionUser } from '@/shared/utils/getSessionUser'
+import { extractDataOrThrow } from '@/shared/utils/extractDataOrThrow'
 import { fail, Result, success } from '@/shared/utils/result'
 
-export async function createPaymentAction(formData: PaymentFormData): Promise<Result<null>> {
+export async function createPaymentAction(formData: PaymentFormData): Promise<Result<{ url: string | null }>> {
   try {
+    if (formData.payment_method === 'stripe') {
+      const { supabase, user } = await getSessionUser()
+
+      // Vérifier que la facture appartient à l'utilisateur et récupérer la devise
+      const res = await supabase
+        .from('invoices')
+        .select('*, client:clients(name)')
+        .eq('id', formData.invoice_id)
+        .single()
+      const invoice = extractDataOrThrow<any>(res)
+      if (invoice.user_id !== user.id) throw new Error('Facture non trouvée ou non autorisée')
+
+      const stripe = new Stripe(process.env.STRIPE_SECRET_KEY!, { apiVersion: '2024-04-10' })
+
+      const session = await stripe.checkout.sessions.create({
+        payment_method_types: ['card'],
+        mode: 'payment',
+        line_items: [
+          {
+            price_data: {
+              currency: invoice.currency,
+              unit_amount: Math.round(formData.amount * 100),
+              product_data: { name: invoice.invoice_number },
+            },
+            quantity: 1,
+          },
+        ],
+        metadata: {
+          invoice_id: formData.invoice_id,
+        },
+        success_url: `${process.env.NEXT_PUBLIC_SITE_URL}/dashboard/payments`,
+        cancel_url: `${process.env.NEXT_PUBLIC_SITE_URL}/dashboard/payments`,
+      })
+
+      return success({ url: session.url })
+    }
+
     await createPayment(formData)
-    revalidatePath("/dashboard/payments")
-    return success(null)
+    revalidatePath('/dashboard/payments')
+    return success({ url: null })
   } catch (error) {
     return fail((error as Error).message)
   }

--- a/features/payment/create/hooks/useNewPaymentForm.ts
+++ b/features/payment/create/hooks/useNewPaymentForm.ts
@@ -43,6 +43,10 @@ export function useNewPaymentForm(invoices: Invoice[]) {
     setError(null)
     const result = await createPaymentAction(values)
     if (result.success) {
+      if (result.data.url) {
+        window.location.href = result.data.url
+        return
+      }
       router.push("/dashboard/payments")
       router.refresh()
     } else {

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "react-resizable-panels": "^2.1.7",
     "recharts": "latest",
     "resend": "^4.5.1",
+    "stripe": "latest",
     "sonner": "^1.7.1",
     "tailwind-merge": "^2.5.5",
     "tailwindcss-animate": "^1.0.7",


### PR DESCRIPTION
## Summary
- integrate Stripe dependency
- create checkout sessions when the payment method is Stripe
- handle Stripe webhook to record payments and mark invoices paid
- redirect to Stripe when needed

## Testing
- `npm test` *(fails: jest not found)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: missing type declarations)*