### PR TITLE
Refactor auth form hooks to remove navigation

### DIFF
--- a/features/auth/login/hooks/useLoginForm.ts
+++ b/features/auth/login/hooks/useLoginForm.ts
@@ -1,12 +1,10 @@
 import { useState } from "react";
-import { useRouter } from "next/navigation";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { loginSchema, LoginSchema } from "@/features/auth/shared/schema/auth.schema";
 import { loginUserAction } from "@/features/auth/login/actions/loginUser.action";
 
 export function useLoginForm() {
-  const router = useRouter();
   const [serverError, setServerError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
 
@@ -19,21 +17,20 @@ export function useLoginForm() {
   });
 
   const onSubmit = async (data: LoginSchema) => {
-    setServerError(null);
-    setIsLoading(true);
+    setServerError(null)
+    setIsLoading(true)
     const formData = new FormData();
     formData.append("email", data.email);
     formData.append("password", data.password);
 
-    const res = await loginUserAction(formData);
-    setIsLoading(false);
+    const res = await loginUserAction(formData)
+    setIsLoading(false)
 
     if (!res.success) {
-      setServerError(res.error || "Erreur inconnue");
-    } else {
-      router.push("/dashboard");
-      router.refresh();
+      setServerError(res.error || "Erreur inconnue")
+      return false
     }
+    return true
   };
 
   return { form, onSubmit, serverError, isLoading };

--- a/features/auth/login/ui/LoginForm.tsx
+++ b/features/auth/login/ui/LoginForm.tsx
@@ -1,16 +1,27 @@
 "use client"
 
+import { useRouter } from "next/navigation"
 import { useLoginForm } from "@/features/auth/login/hooks/useLoginForm"
 import { LoginFormView } from "@/features/auth/login/ui/LoginFormView"
 
 export function LoginForm() {
-  const { form, onSubmit, serverError, isLoading } = useLoginForm();
+  const router = useRouter()
+  const { form, onSubmit, serverError, isLoading } = useLoginForm()
+
+  const handleSubmit = async (data: Parameters<typeof onSubmit>[0]) => {
+    const success = await onSubmit(data)
+    if (success) {
+      router.push("/dashboard")
+      router.refresh()
+    }
+  }
+
   return (
     <LoginFormView
       form={form}
-      onSubmit={onSubmit}
+      onSubmit={handleSubmit}
       serverError={serverError}
       isLoading={isLoading}
     />
-  );
+  )
 }

--- a/features/auth/register/hooks/useRegisterForm.ts
+++ b/features/auth/register/hooks/useRegisterForm.ts
@@ -1,12 +1,10 @@
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useState } from "react";
-import { useRouter } from "next/navigation";
 import { registerSchema, RegisterSchema } from "@/features/auth/shared/schema/auth.schema";
 import { registerUserAction } from "@/features/auth/register/actions/registerUser.action";
 
 export function useRegisterForm() {
-  const router = useRouter();
   const [serverError, setServerError] = useState<string | null>(null);
 
   const form = useForm<RegisterSchema>({
@@ -19,19 +17,19 @@ export function useRegisterForm() {
   });
 
   const onSubmit = async (data: RegisterSchema) => {
-    setServerError(null);
+    setServerError(null)
     const formData = new FormData();
     formData.append("full_name", data.full_name);
     formData.append("email", data.email);
     formData.append("password", data.password);
 
-    const res = await registerUserAction(formData);
+    const res = await registerUserAction(formData)
 
     if (!res.success) {
-      setServerError(res.error || "Erreur inconnue");
-    } else {
-      router.push("/register/confirmation");
+      setServerError(res.error || "Erreur inconnue")
+      return false
     }
+    return true
   };
 
   return { form, onSubmit, serverError };

--- a/features/auth/register/ui/RegisterForm.tsx
+++ b/features/auth/register/ui/RegisterForm.tsx
@@ -1,15 +1,25 @@
 'use client'
 
+import { useRouter } from "next/navigation";
 import { useRegisterForm } from "@/features/auth/register/hooks/useRegisterForm";
 import { RegisterFormView } from "@/features/auth/register/ui/RegisterFormView";
 
 export function RegisterForm() {
-  const { form, onSubmit, serverError } = useRegisterForm();
+  const router = useRouter()
+  const { form, onSubmit, serverError } = useRegisterForm()
+
+  const handleSubmit = async (data: Parameters<typeof onSubmit>[0]) => {
+    const success = await onSubmit(data)
+    if (success) {
+      router.push("/register/confirmation")
+    }
+  }
+
   return (
     <RegisterFormView
       form={form}
-      onSubmit={onSubmit}
+      onSubmit={handleSubmit}
       serverError={serverError}
     />
-  );
+  )
 }


### PR DESCRIPTION
## Summary
- keep `useLoginForm` focused on form logic
- keep `useRegisterForm` focused on form logic
- handle redirects inside `LoginForm` and `RegisterForm`

## Testing
- `npm test` *(fails: jest not found)*