### PR TITLE
Refactor auth actions

### DIFF
--- a/features/auth/login/actions/loginUser.action.ts
+++ b/features/auth/login/actions/loginUser.action.ts
@@ -1,7 +1,7 @@
 'use server'
 
 import { LoginSchema, loginSchema } from '@/features/auth/shared/schema/auth.schema'
-import { createClient } from '@/shared/lib/supabase/server'
+import { signInWithEmail } from '@/shared/services/auth'
 import { FormResult } from '@/shared/types/api.types'
 import { safeParseForm } from '@/shared/utils/safeParseForm'
 
@@ -10,12 +10,10 @@ export async function loginUserAction(formData: FormData): Promise<FormResult<Lo
   if (!parsed.success) return parsed
 
   const { email, password } = parsed.data
-  const supabase = await createClient()
 
-  const { error } = await supabase.auth.signInWithPassword({ email, password })
-
+  const { error } = await signInWithEmail(email, password)
   if (error) {
-    return { success: false, error: error.message }
+    return { success: false, error }
   }
 
   return { success: true, data: parsed.data }

--- a/shared/services/auth.ts
+++ b/shared/services/auth.ts
@@ -1,0 +1,33 @@
+import { createClient } from '@/shared/lib/supabase/server'
+
+export async function signInWithEmail(email: string, password: string) {
+  const supabase = await createClient()
+  const { error } = await supabase.auth.signInWithPassword({ email, password })
+  return { error: error ? error.message : null }
+}
+
+export async function signUpWithEmail(email: string, password: string, full_name: string) {
+  const supabase = await createClient()
+
+  const { data: authData, error: authError } = await supabase.auth.signUp({
+    email,
+    password,
+    options: {
+      data: { full_name },
+      emailRedirectTo: `${process.env.NEXT_PUBLIC_SITE_URL}/auth/callback`,
+    },
+  })
+
+  if (authError) return { error: authError.message }
+
+  if (authData.user) {
+    const { error: profileError } = await supabase.from('profiles').insert({
+      id: authData.user.id,
+      email,
+      full_name,
+    })
+    if (profileError) return { error: profileError.message }
+  }
+
+  return { error: null }
+}


### PR DESCRIPTION
## Summary
- centralize auth login and register logic in a new service
- use the service from login and register actions

## Testing
- `npm test` *(fails: jest not found)*