### PR TITLE
Add registration confirmation page

### DIFF
--- a/app/(auth)/register/confirmation/page.tsx
+++ b/app/(auth)/register/confirmation/page.tsx
@@ -1,0 +1,21 @@
+import { ResendConfirmationForm } from '@/features/auth/resend-confirmation/ui/ResendConfirmationForm'
+import { redirectIfAuthenticated } from '@/shared/utils/redirectIfAuthenticated'
+
+export default async function RegisterConfirmationPage() {
+  await redirectIfAuthenticated()
+
+  return (
+    <div className="flex min-h-screen items-center justify-center py-12 px-4 sm:px-6 lg:px-8">
+      <div className="w-full max-w-md space-y-8 text-center">
+        <h1 className="text-2xl font-bold">Confirmez votre email</h1>
+        <p className="mt-2 text-sm text-gray-600">
+          Nous vous avons envoyé un email de confirmation. Cliquez sur le lien contenu dans cet email pour activer votre compte.
+        </p>
+        <p className="mt-2 text-sm text-gray-600">
+          Pas reçu l'email ? Vous pouvez le renvoyer ci-dessous.
+        </p>
+        <ResendConfirmationForm />
+      </div>
+    </div>
+  )
+}

--- a/features/auth/resend-confirmation/actions/resendConfirmation.action.ts
+++ b/features/auth/resend-confirmation/actions/resendConfirmation.action.ts
@@ -1,0 +1,23 @@
+'use server'
+
+import { ResendConfirmationSchema, resendConfirmationSchema } from '@/features/auth/shared/schema/auth.schema'
+import { createClient } from '@/shared/lib/supabase/server'
+import type { FormResult } from '@/shared/types/api.types'
+import { safeParseForm } from '@/shared/utils/safeParseForm'
+
+export async function resendConfirmationAction(formData: FormData): Promise<FormResult<ResendConfirmationSchema>> {
+  const parsed = await safeParseForm(formData, resendConfirmationSchema)
+  if (!parsed.success) return parsed
+
+  const { email } = parsed.data
+  const supabase = await createClient()
+
+  const { error } = await supabase.auth.resend({
+    type: 'signup',
+    email,
+  })
+
+  if (error) return { success: false, error: error.message }
+
+  return { success: true, data: parsed.data }
+}

--- a/features/auth/resend-confirmation/hooks/useResendConfirmationForm.ts
+++ b/features/auth/resend-confirmation/hooks/useResendConfirmationForm.ts
@@ -1,0 +1,31 @@
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { useState } from 'react'
+import { resendConfirmationSchema, ResendConfirmationSchema } from '@/features/auth/shared/schema/auth.schema'
+import { resendConfirmationAction } from '@/features/auth/resend-confirmation/actions/resendConfirmation.action'
+
+export function useResendConfirmationForm() {
+  const [serverError, setServerError] = useState<string | null>(null)
+  const [sent, setSent] = useState(false)
+
+  const form = useForm<ResendConfirmationSchema>({
+    resolver: zodResolver(resendConfirmationSchema),
+    defaultValues: { email: '' },
+  })
+
+  const onSubmit = async (data: ResendConfirmationSchema) => {
+    setServerError(null)
+    const formData = new FormData()
+    formData.append('email', data.email)
+
+    const res = await resendConfirmationAction(formData)
+
+    if (!res.success) {
+      setServerError(res.error || 'Erreur inconnue')
+    } else {
+      setSent(true)
+    }
+  }
+
+  return { form, onSubmit, serverError, sent }
+}

--- a/features/auth/resend-confirmation/ui/ResendConfirmationForm.tsx
+++ b/features/auth/resend-confirmation/ui/ResendConfirmationForm.tsx
@@ -1,0 +1,16 @@
+'use client'
+
+import { useResendConfirmationForm } from '@/features/auth/resend-confirmation/hooks/useResendConfirmationForm'
+import { ResendConfirmationFormView } from '@/features/auth/resend-confirmation/ui/ResendConfirmationFormView'
+
+export function ResendConfirmationForm() {
+  const { form, onSubmit, serverError, sent } = useResendConfirmationForm()
+  return (
+    <ResendConfirmationFormView
+      form={form}
+      onSubmit={onSubmit}
+      serverError={serverError}
+      sent={sent}
+    />
+  )
+}

--- a/features/auth/resend-confirmation/ui/ResendConfirmationFormView.tsx
+++ b/features/auth/resend-confirmation/ui/ResendConfirmationFormView.tsx
@@ -1,0 +1,49 @@
+import { Form, FormField, FormItem, FormLabel, FormControl, FormMessage } from '@/components/ui/form'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Alert } from '@/components/ui/alert'
+import { UseFormReturn } from 'react-hook-form'
+import { ResendConfirmationSchema } from '@/features/auth/shared/schema/auth.schema'
+
+interface ResendConfirmationFormViewProps {
+  form: UseFormReturn<ResendConfirmationSchema>
+  onSubmit: (data: ResendConfirmationSchema) => void
+  serverError: string | null
+  sent: boolean
+}
+
+export function ResendConfirmationFormView({ form, onSubmit, serverError, sent }: ResendConfirmationFormViewProps) {
+  if (sent) {
+    return (
+      <Alert variant="default">
+        📩 Si un compte existe avec cet email et n'est pas vérifié, un nouveau lien de confirmation a été envoyé.
+      </Alert>
+    )
+  }
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+        {serverError && (
+          <div className="mb-2 text-sm text-destructive font-medium">{serverError}</div>
+        )}
+        <FormField
+          control={form.control}
+          name="email"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Email</FormLabel>
+              <FormControl>
+                <Input type="email" autoComplete="email" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <Button type="submit" className="w-full" disabled={form.formState.isSubmitting}>
+          {form.formState.isSubmitting ? 'Envoi en cours...' : "Renvoyer l'email de confirmation"}
+        </Button>
+      </form>
+    </Form>
+  )
+}


### PR DESCRIPTION
## Summary
- add confirmation page when registering
- add resend confirmation form action and hook
- show instructions and resend form after signup

## Testing
- `pnpm test` *(fails: jest not found)*
- `pnpm lint` *(fails: next not found)*