### PR TITLE
Implement caching for server supabase client

### DIFF
--- a/shared/lib/supabase/server.ts
+++ b/shared/lib/supabase/server.ts
@@ -1,8 +1,9 @@
 import { createServerClient } from "@supabase/ssr"
 import { cookies } from "next/headers"
+import { cache } from "react"
 
-export async function createClient() {
-  const cookieStore = await cookies()
+export const createClient = cache(() => {
+  const cookieStore = cookies()
 
   return createServerClient(process.env.NEXT_PUBLIC_SUPABASE_URL!, process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!, {
     cookies: {
@@ -20,4 +21,4 @@ export async function createClient() {
       },
     },
   })
-}
+})


### PR DESCRIPTION
## Summary
- cache `createClient` in `server.ts` using `react`'s `cache`

## Testing
- `pnpm test` *(fails: jest not found)*