### PR TITLE
Add password reset page

### DIFF
--- a/app/(auth)/reset-password/page.tsx
+++ b/app/(auth)/reset-password/page.tsx
@@ -1,0 +1,26 @@
+import { ResetPasswordForm } from '@/features/auth/reset/ui/ResetPasswordForm'
+import { createClient } from '@/shared/lib/supabase/server'
+import { redirect } from 'next/navigation'
+
+export default async function ResetPasswordPage() {
+  const supabase = await createClient()
+  const {
+    data: { session },
+  } = await supabase.auth.getSession()
+
+  if (!session) {
+    redirect('/login')
+  }
+
+  return (
+    <div className="flex min-h-screen items-center justify-center py-12 px-4 sm:px-6 lg:px-8">
+      <div className="w-full max-w-md space-y-8">
+        <div className="text-center">
+          <h1 className="text-2xl font-bold">Définir un nouveau mot de passe</h1>
+          <p className="mt-2 text-sm text-gray-600">Entrez votre nouveau mot de passe ci-dessous</p>
+        </div>
+        <ResetPasswordForm />
+      </div>
+    </div>
+  )
+}

--- a/features/auth/reset/actions/resetPassword.action.ts
+++ b/features/auth/reset/actions/resetPassword.action.ts
@@ -1,0 +1,19 @@
+'use server'
+
+import { resetPasswordSchema, ResetPasswordSchema } from '@/features/auth/shared/schema/auth.schema'
+import { createClient } from '@/shared/lib/supabase/server'
+import type { FormResult } from '@/shared/types/api.types'
+import { safeParseForm } from '@/shared/utils/safeParseForm'
+
+export async function resetPasswordAction(formData: FormData): Promise<FormResult<ResetPasswordSchema>> {
+  const parsed = await safeParseForm(formData, resetPasswordSchema)
+  if (!parsed.success) return parsed
+
+  const { password } = parsed.data
+  const supabase = await createClient()
+  const { error } = await supabase.auth.updateUser({ password })
+
+  if (error) return { success: false, error: error.message }
+
+  return { success: true, data: parsed.data }
+}

--- a/features/auth/reset/hooks/useResetPasswordForm.ts
+++ b/features/auth/reset/hooks/useResetPasswordForm.ts
@@ -1,0 +1,32 @@
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { resetPasswordSchema, ResetPasswordSchema } from '@/features/auth/shared/schema/auth.schema'
+import { resetPasswordAction } from '@/features/auth/reset/actions/resetPassword.action'
+
+export function useResetPasswordForm() {
+  const router = useRouter()
+  const [serverError, setServerError] = useState<string | null>(null)
+
+  const form = useForm<ResetPasswordSchema>({
+    resolver: zodResolver(resetPasswordSchema),
+    defaultValues: { password: '' },
+  })
+
+  const onSubmit = async (data: ResetPasswordSchema) => {
+    setServerError(null)
+    const formData = new FormData()
+    formData.append('password', data.password)
+
+    const res = await resetPasswordAction(formData)
+
+    if (!res.success) {
+      setServerError(res.error || 'Erreur inconnue')
+    } else {
+      router.push('/login')
+    }
+  }
+
+  return { form, onSubmit, serverError }
+}

--- a/features/auth/reset/ui/ResetPasswordForm.tsx
+++ b/features/auth/reset/ui/ResetPasswordForm.tsx
@@ -1,0 +1,9 @@
+'use client'
+
+import { useResetPasswordForm } from '@/features/auth/reset/hooks/useResetPasswordForm'
+import { ResetPasswordFormView } from '@/features/auth/reset/ui/ResetPasswordFormView'
+
+export function ResetPasswordForm() {
+  const { form, onSubmit, serverError } = useResetPasswordForm()
+  return <ResetPasswordFormView form={form} onSubmit={onSubmit} serverError={serverError} />
+}

--- a/features/auth/reset/ui/ResetPasswordFormView.tsx
+++ b/features/auth/reset/ui/ResetPasswordFormView.tsx
@@ -1,0 +1,39 @@
+import { Form, FormField, FormItem, FormLabel, FormControl, FormMessage } from '@/components/ui/form'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { UseFormReturn } from 'react-hook-form'
+import { ResetPasswordSchema } from '@/features/auth/shared/schema/auth.schema'
+
+interface ResetPasswordFormViewProps {
+  form: UseFormReturn<ResetPasswordSchema>
+  onSubmit: (data: ResetPasswordSchema) => void
+  serverError: string | null
+}
+
+export function ResetPasswordFormView({ form, onSubmit, serverError }: ResetPasswordFormViewProps) {
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+        {serverError && (
+          <div className="mb-2 text-sm text-destructive font-medium">{serverError}</div>
+        )}
+        <FormField
+          control={form.control}
+          name="password"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Nouveau mot de passe</FormLabel>
+              <FormControl>
+                <Input type="password" autoComplete="new-password" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <Button type="submit" className="w-full" disabled={form.formState.isSubmitting}>
+          {form.formState.isSubmitting ? 'Mise à jour...' : 'Mettre à jour'}
+        </Button>
+      </form>
+    </Form>
+  )
+}

--- a/features/auth/shared/schema/auth.schema.ts
+++ b/features/auth/shared/schema/auth.schema.ts
@@ -1,25 +1,30 @@
 import { z } from 'zod'
 
 export const registerSchema = z.object({
-    email: z.string().email("Email invalide"),
-    password: z.string().min(6, "Le mot de passe doit contenir au moins 6 caractères"),
-    full_name: z.string().min(2, "Le nom complet est requis"),
+  email: z.string().email('Email invalide'),
+  password: z.string().min(6, 'Le mot de passe doit contenir au moins 6 caractères'),
+  full_name: z.string().min(2, 'Le nom complet est requis'),
 })
 
 export const loginSchema = z.object({
-    email: z.string().email("Email invalide"),
-    password: z.string().min(6, "Mot de passe requis"),
+  email: z.string().email('Email invalide'),
+  password: z.string().min(6, 'Mot de passe requis'),
 })
 
 export const forgotPasswordSchema = z.object({
-    email: z.string().email("Email invalide"),
+  email: z.string().email('Email invalide'),
 })
 
 export const resendConfirmationSchema = z.object({
-    email: z.string().email("Email invalide"),
+  email: z.string().email('Email invalide'),
+})
+
+export const resetPasswordSchema = z.object({
+  password: z.string().min(6, 'Le mot de passe doit contenir au moins 6 caractères'),
 })
 
 export type RegisterSchema = z.infer<typeof registerSchema>
 export type LoginSchema = z.infer<typeof loginSchema>
 export type ForgotPasswordSchema = z.infer<typeof forgotPasswordSchema>
 export type ResendConfirmationSchema = z.infer<typeof resendConfirmationSchema>
+export type ResetPasswordSchema = z.infer<typeof resetPasswordSchema>


### PR DESCRIPTION
## Summary
- add `resetPasswordSchema`
- create reset password server action and hook
- display reset password form
- wire new `/auth/reset-password` page

## Testing
- `npm test` *(fails: jest not found)*