### PR TITLE
Fix middleware auth path exceptions

### DIFF
--- a/shared/lib/supabase/middleware.ts
+++ b/shared/lib/supabase/middleware.ts
@@ -40,7 +40,9 @@ export async function updateSession(request: NextRequest) {
   if (
     !user &&
     !request.nextUrl.pathname.startsWith('/login') &&
-    !request.nextUrl.pathname.startsWith('/auth')
+    !request.nextUrl.pathname.startsWith('/auth') &&
+    !request.nextUrl.pathname.startsWith('/register') &&
+    !request.nextUrl.pathname.startsWith('/forgot-password')
   ) {
     // no user, potentially respond by redirecting the user to the login page
     const url = request.nextUrl.clone()


### PR DESCRIPTION
## Summary
- allow unauthenticated users to visit `/register` and `/forgot-password`

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm test` *(fails: `jest` not found)*