### PR TITLE
refactor: share payment form logic

### DIFF
--- a/features/payment/create/hooks/useNewPaymentForm.ts
+++ b/features/payment/create/hooks/useNewPaymentForm.ts
@@ -3,23 +3,9 @@ import { useRouter } from "next/navigation"
 import { useState } from "react"
 import { createPaymentAction } from "@/features/payment/create/actions/createPayment.action"
 import { Invoice } from "@/features/invoice/shared/types/invoice.types"
-import { useForm } from "react-hook-form"
-import { zodResolver } from "@hookform/resolvers/zod"
-import { PaymentFormSchema, paymentFormSchema } from "@/features/payment/shared/schema/payment.schema"
+import { PaymentFormSchema } from "@/features/payment/shared/schema/payment.schema"
+import { usePaymentForm } from "@/shared/hooks/usePaymentForm"
 
-function usePaymentForm(defaults: Partial<PaymentFormSchema> = {}) {
-  return useForm<PaymentFormSchema>({
-    resolver: zodResolver(paymentFormSchema),
-    defaultValues: {
-      invoice_id: defaults.invoice_id || "",
-      amount: defaults.amount ?? 0,
-      payment_date: defaults.payment_date || new Date(),
-      payment_method: defaults.payment_method || "transfer",
-      notes: defaults.notes || "",
-    },
-    mode: "onBlur",
-  })
-}
 
 export function useNewPaymentForm(invoices: Invoice[]) {
   const router = useRouter()

--- a/features/payment/edit/hooks/useEditPaymentForm.ts
+++ b/features/payment/edit/hooks/useEditPaymentForm.ts
@@ -4,34 +4,9 @@ import { useState } from "react"
 import { updatePaymentAction } from "@/features/payment/edit/actions/updatePayment.action"
 import { Payment } from "@/features/payment/shared/types/payment.types"
 import { Invoice } from "@/features/invoice/shared/types/invoice.types"
-import { useForm } from "react-hook-form"
-import { zodResolver } from "@hookform/resolvers/zod"
-import { z } from "zod"
 import { PaymentFormData } from "@/features/payment/shared/types/payment.types"
-
-const paymentFormSchema = z.object({
-  invoice_id: z.string().min(1, "La facture est requise"),
-  amount: z.number().min(0.01, "Le montant doit être positif"),
-  payment_date: z.date({ required_error: "La date est requise" }),
-  payment_method: z.string().min(1, "La méthode est requise"),
-  notes: z.string(),
-})
-
-export type PaymentFormSchema = z.infer<typeof paymentFormSchema>
-
-function usePaymentForm(defaults: Partial<PaymentFormSchema> = {}) {
-  return useForm<PaymentFormSchema>({
-    resolver: zodResolver(paymentFormSchema),
-    defaultValues: {
-      invoice_id: defaults.invoice_id || "",
-      amount: defaults.amount ?? 0,
-      payment_date: defaults.payment_date ? new Date(defaults.payment_date) : new Date(),
-      payment_method: defaults.payment_method || "transfer",
-      notes: defaults.notes || "",
-    },
-    mode: "onBlur",
-  })
-}
+import { PaymentFormSchema } from "@/features/payment/shared/schema/payment.schema"
+import { usePaymentForm } from "@/shared/hooks/usePaymentForm"
 
 export function useEditPaymentForm(payment: Payment, invoices: Invoice[]) {
   const router = useRouter()

--- a/features/payment/edit/ui/EditPaymentFormView.tsx
+++ b/features/payment/edit/ui/EditPaymentFormView.tsx
@@ -10,7 +10,7 @@ import { formatCurrency } from "@/shared/lib/utils"
 import { DatePicker } from "@/components/ui/date-picker"
 import { Invoice } from "@/features/invoice/shared/types/invoice.types"
 import { Form, FormField, FormItem, FormLabel, FormControl, FormMessage } from "@/components/ui/form"
-import { PaymentFormSchema } from "@/features/payment/edit/hooks/useEditPaymentForm"
+import { PaymentFormSchema } from "@/features/payment/shared/schema/payment.schema"
 
 interface EditPaymentFormViewProps {
   form: any

--- a/shared/hooks/usePaymentForm.ts
+++ b/shared/hooks/usePaymentForm.ts
@@ -1,0 +1,17 @@
+import { useForm } from "react-hook-form"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { PaymentFormSchema, paymentFormSchema } from "@/features/payment/shared/schema/payment.schema"
+
+export function usePaymentForm(defaults: Partial<PaymentFormSchema> = {}) {
+  return useForm<PaymentFormSchema>({
+    resolver: zodResolver(paymentFormSchema),
+    defaultValues: {
+      invoice_id: defaults.invoice_id || "",
+      amount: defaults.amount ?? 0,
+      payment_date: defaults.payment_date ? new Date(defaults.payment_date) : new Date(),
+      payment_method: defaults.payment_method || "transfer",
+      notes: defaults.notes || "",
+    },
+    mode: "onBlur",
+  })
+}


### PR DESCRIPTION
## Summary
- add global `usePaymentForm` hook for reuse
- use the shared hook in new and edit payment forms

## Testing
- `npm test` *(fails: jest not found)*