### PR TITLE
Refactor payment method label utility

### DIFF
--- a/features/payment/list/hooks/usePaymentsTable.ts
+++ b/features/payment/list/hooks/usePaymentsTable.ts
@@ -2,6 +2,7 @@ import { useState } from "react"
 import { useRouter } from "next/navigation"
 import { deletePaymentAction } from "@/features/payment/delete/actions/deletePayment.action"
 import { Payment } from "@/features/payment/shared/types/payment.types"
+import { getPaymentMethodLabel } from "@/features/payment/shared/utils/paymentMethod"
 
 export function usePaymentsTable(payments: Payment[]) {
   const router = useRouter()
@@ -37,20 +38,6 @@ export function usePaymentsTable(payments: Payment[]) {
     }
   }
 
-  const getPaymentMethodLabel = (method: string) => {
-    switch (method) {
-      case "card":
-        return "Carte bancaire"
-      case "cash":
-        return "Espèces"
-      case "transfer":
-        return "Virement"
-      case "stripe":
-        return "Stripe"
-      default:
-        return method
-    }
-  }
 
   return {
     searchTerm,

--- a/features/payment/shared/utils/paymentMethod.ts
+++ b/features/payment/shared/utils/paymentMethod.ts
@@ -1,0 +1,14 @@
+export function getPaymentMethodLabel(method: string): string {
+  switch (method) {
+    case "card":
+      return "Carte bancaire";
+    case "cash":
+      return "Espèces";
+    case "transfer":
+      return "Virement";
+    case "stripe":
+      return "Stripe";
+    default:
+      return method;
+  }
+}

--- a/features/payment/view/hooks/usePaymentDetails.ts
+++ b/features/payment/view/hooks/usePaymentDetails.ts
@@ -2,26 +2,13 @@ import { useState } from "react"
 import { useRouter } from "next/navigation"
 import { createClient } from "@/shared/lib/supabase/client"
 import { Payment } from "@/features/payment/shared/types/payment.types"
+import { getPaymentMethodLabel } from "@/features/payment/shared/utils/paymentMethod"
 
 export function usePaymentDetails(payment: Payment) {
   const router = useRouter()
   const supabase = createClient()
   const [isDeleting, setIsDeleting] = useState(false)
 
-  const getPaymentMethodLabel = (method: string) => {
-    switch (method) {
-      case "card":
-        return "Carte bancaire"
-      case "cash":
-        return "Espèces"
-      case "transfer":
-        return "Virement"
-      case "stripe":
-        return "Stripe"
-      default:
-        return method
-    }
-  }
 
   const handleDelete = async () => {
     setIsDeleting(true)


### PR DESCRIPTION
## Summary
- centralize `getPaymentMethodLabel` helper
- use the new helper in payment table and payment details hooks

## Testing
- `npm test` *(fails: jest not found)*