### PR TITLE
Remove image unoptimized setting

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -7,7 +7,7 @@ const nextConfig = {
     ignoreBuildErrors: true,
   },
   images: {
-    unoptimized: true,
+    unoptimized: false,
   },
 }
 


### PR DESCRIPTION
## Summary
- disable the unoptimized flag for the Next.js Image component

## Testing
- `npm test --silent` *(fails: `jest` not found)*