### PR TITLE
Fix lazy loading for ProductSelector

### DIFF
--- a/features/product/shared/ui/ProductSelector.tsx
+++ b/features/product/shared/ui/ProductSelector.tsx
@@ -23,10 +23,12 @@ export function ProductSelector({ userId, onSelect, buttonClassName }: ProductSe
   const [dialogOpen, setDialogOpen] = useState(false)
   const supabase = createClient()
 
-  // Fetch products when component mounts
+  // Fetch products when popover opens and no products are loaded yet
   useEffect(() => {
-    fetchProducts()
-  }, [])
+    if (open && products.length === 0) {
+      fetchProducts()
+    }
+  }, [open, products.length])
 
   const fetchProducts = async () => {
     setLoading(true)


### PR DESCRIPTION
## Summary
- load products once the selector popover is opened instead of on mount

## Testing
- `npm test` *(fails: jest not found)*