### PR TITLE
Enhance time tracking links to tasks

### DIFF
--- a/features/project/edit/model/getProjectDetails.ts
+++ b/features/project/edit/model/getProjectDetails.ts
@@ -10,7 +10,7 @@ export async function getProjectDetails(projectId: string): Promise<Project> {
     .select(`
       *,
       clients(name),
-      tasks(*)
+      tasks(*, time_entries(*))
     `)
     .eq("id", projectId)
     .eq("user_id", user.id)

--- a/features/task/shared/types/task.types.ts
+++ b/features/task/shared/types/task.types.ts
@@ -1,3 +1,5 @@
+import { TimeEntry } from '@/features/time-tracking/shared/types/timeEntry.types'
+
 export interface Task {
   id: string;
   project_id: string;
@@ -12,6 +14,7 @@ export interface Task {
   priority: string;
   updated_at?: string;
   subtasks?: Task[];
+  time_entries?: TimeEntry[];
 }
 
 export interface TaskFormData {

--- a/features/time-tracking/shared/ui/TimeEntryForm.tsx
+++ b/features/time-tracking/shared/ui/TimeEntryForm.tsx
@@ -1,16 +1,42 @@
 'use client'
 
+import { useEffect, useState } from 'react'
+import { createClient } from '@/shared/lib/supabase/client'
 import { Project } from '@/features/project/shared/types/project.types'
 import { TimeEntry } from '@/features/time-tracking/shared/types/timeEntry.types'
+import { Task } from '@/features/task/shared/types/task.types'
 import { useTimeEntryForm } from '@/features/time-tracking/shared/hooks/useTimeEntryForm'
 import { TimeEntryFormView } from '@/features/time-tracking/shared/ui/TimeEntryFormView'
 
 export function TimeEntryForm({ projects, entry, onSuccess }: { projects: Project[]; entry: TimeEntry | null; onSuccess?: () => void }) {
   const form = useTimeEntryForm({ entry, onSuccess })
+  const supabase = createClient()
+  const [tasks, setTasks] = useState<Task[]>([])
+
+  useEffect(() => {
+    async function loadTasks() {
+      if (!form.formData.project_id) {
+        setTasks([])
+        return
+      }
+      const { data, error } = await supabase
+        .from('tasks')
+        .select('*')
+        .eq('project_id', form.formData.project_id)
+      if (!error && data) {
+        setTasks(data as Task[])
+      } else {
+        setTasks([])
+      }
+    }
+
+    loadTasks()
+  }, [form.formData.project_id])
 
   return (
     <TimeEntryFormView
       projects={projects}
+      tasks={tasks}
       formData={form.formData}
       onChange={form.handleChange}
       onSubmit={form.handleSubmit}

--- a/features/time-tracking/shared/ui/TimeEntryFormView.tsx
+++ b/features/time-tracking/shared/ui/TimeEntryFormView.tsx
@@ -8,9 +8,11 @@ import { AlertCircle, Loader2 } from 'lucide-react'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { DatePicker } from '@/components/ui/date-picker'
 import { Project } from '@/features/project/shared/types/project.types'
+import { Task } from '@/features/task/shared/types/task.types'
 
 interface TimeEntryFormViewProps {
   projects: Project[]
+  tasks: Task[]
   formData: {
     project_id: string
     task_id: string | null
@@ -27,6 +29,7 @@ interface TimeEntryFormViewProps {
 
 export function TimeEntryFormView({
   projects,
+  tasks,
   formData,
   onChange,
   onSubmit,
@@ -59,7 +62,20 @@ export function TimeEntryFormView({
 
       <div className="space-y-2">
         <Label htmlFor="task_id">Tâche (optionnel)</Label>
-        <Input id="task_id" value={formData.task_id || ''} onChange={(e) => onChange('task_id', e.target.value)} />
+        <Select
+          value={formData.task_id || ''}
+          onValueChange={(value) => onChange('task_id', value)}
+        >
+          <SelectTrigger id="task_id">
+            <SelectValue placeholder="Sélectionner une tâche" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="">Aucune</SelectItem>
+            {tasks.map((t) => (
+              <SelectItem key={t.id} value={t.id}>{t.name}</SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
       </div>
 
       <div className="grid gap-4 sm:grid-cols-2">


### PR DESCRIPTION
## Summary
- allow selection of tasks when creating/editing a time entry
- include time tracking data when fetching project details
- update task type with optional `time_entries`

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*