### PR TITLE
Add draggable Kanban board

### DIFF
--- a/features/project/shared/ui/ProjectDetailsView.tsx
+++ b/features/project/shared/ui/ProjectDetailsView.tsx
@@ -227,7 +227,7 @@ export const ProjectDetailsView: React.FC<ProjectDetailsViewProps> = ({
                 </DialogHeader>
                 <TaskForm
                   projectId={project.id}
-                  task={null as unknown as Task}
+                  task={null}
                   onSuccess={() => {
                     setTaskDialogOpen(false)
                     router.refresh()
@@ -253,7 +253,11 @@ export const ProjectDetailsView: React.FC<ProjectDetailsViewProps> = ({
         <TaskGantt tasks={filteredTasks} projectStartDate={project.start_date} />
       </TabsContent>
       <TabsContent value="kanban">
-        <TaskKanban tasks={filteredTasks} />
+        <TaskKanban
+          tasks={filteredTasks}
+          projectId={project.id}
+          onTaskUpdate={() => router.refresh()}
+        />
       </TabsContent>
     </Tabs>
   </div>

--- a/features/task/shared/hooks/useTaskForm.ts
+++ b/features/task/shared/hooks/useTaskForm.ts
@@ -7,16 +7,17 @@ interface UseTaskFormProps {
   projectId: string
   task: Task | null
   onSuccess: () => void
+  defaultStatus?: string
 }
 
-export function useTaskForm({ projectId, task, onSuccess }: UseTaskFormProps) {
+export function useTaskForm({ projectId, task, onSuccess, defaultStatus }: UseTaskFormProps) {
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
   const [formData, setFormData] = useState({
     name: task?.name || "",
     description: task?.description || "",
-    status: task?.status || "pending",
+    status: task?.status || defaultStatus || "pending",
     priority: task?.priority || "medium",
     estimated_hours: task?.estimated_hours ? String(task.estimated_hours) : "",
     due_date: task?.due_date ? new Date(task.due_date) : null,

--- a/features/task/shared/ui/SortableTaskCard.tsx
+++ b/features/task/shared/ui/SortableTaskCard.tsx
@@ -1,0 +1,69 @@
+import { Task } from "@/features/task/shared/types/task.types"
+import { useSortable } from "@dnd-kit/sortable"
+import { CSS } from "@dnd-kit/utilities"
+import { cn, formatDate } from "@/shared/lib/utils"
+import { Badge } from "@/components/ui/badge"
+import { Clock, AlertTriangle } from "lucide-react"
+
+interface SortableTaskCardProps {
+  task: Task
+  getPriorityBadgeClass: (p: string) => string
+  getStatusBadgeClass: (s: string) => string
+  isOverdue: (d: string | null | undefined) => boolean
+  onClick: () => void
+}
+
+export function SortableTaskCard({
+  task,
+  getPriorityBadgeClass,
+  getStatusBadgeClass,
+  isOverdue,
+  onClick,
+}: SortableTaskCardProps) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id: task.id })
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    zIndex: isDragging ? 10 : 1,
+    opacity: isDragging ? 0.8 : 1,
+  }
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      {...attributes}
+      {...listeners}
+      onClick={onClick}
+      className={cn(
+        "p-2 bg-muted rounded-md cursor-pointer border-l-4",
+        isDragging && "shadow-lg",
+        task.priority === "high" && "border-red-500",
+        task.priority === "medium" && "border-yellow-500",
+        task.priority === "low" && "border-green-500",
+      )}
+    >
+      <div className="flex items-start justify-between gap-2">
+        <div className="font-medium text-sm truncate flex-1">{task.name}</div>
+        <div className="flex-shrink-0 space-x-1 flex items-center">
+          {task.priority && (
+            <Badge className={getPriorityBadgeClass(task.priority)}>{task.priority}</Badge>
+          )}
+          <Badge className={getStatusBadgeClass(task.status)}>{task.status}</Badge>
+        </div>
+      </div>
+      {task.due_date && (
+        <div className="flex items-center text-xs text-muted-foreground mt-1">
+          <Clock className="h-3 w-3 mr-1" />
+          <span className={isOverdue(task.due_date) ? "text-red-500 font-medium" : ""}>
+            {formatDate(task.due_date)}
+          </span>
+          {isOverdue(task.due_date) && task.status !== "completed" && (
+            <AlertTriangle className="h-3 w-3 ml-1 text-red-500" />
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/features/task/shared/ui/TaskForm.tsx
+++ b/features/task/shared/ui/TaskForm.tsx
@@ -7,14 +7,14 @@ import { useTaskForm } from "@/features/task/shared/hooks/useTaskForm"
 import { TaskFormView } from "@/features/task/shared/ui/TaskFormView"
 
 
-export function TaskForm({ projectId, task, onSuccess }: { projectId: string, task: Task, onSuccess: () => void }) {
+export function TaskForm({ projectId, task, onSuccess, defaultStatus }: { projectId: string, task: Task | null, onSuccess: () => void, defaultStatus?: string }) {
   const {
     formData,
     handleChange,
     handleSubmit,
     isLoading,
     error,
-  } = useTaskForm({ projectId, task, onSuccess })
+  } = useTaskForm({ projectId, task, onSuccess, defaultStatus })
 
   return (
     <TaskFormView

--- a/features/task/shared/ui/TaskKanban.tsx
+++ b/features/task/shared/ui/TaskKanban.tsx
@@ -1,36 +1,197 @@
 "use client"
 
+import { useState, useEffect } from "react"
 import { Task } from "@/features/task/shared/types/task.types"
+import { createClient } from "@/shared/lib/supabase/client"
+import { DndContext, closestCorners, DragEndEvent, useSensor, useSensors, PointerSensor } from "@dnd-kit/core"
+import { SortableContext, verticalListSortingStrategy, arrayMove } from "@dnd-kit/sortable"
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog"
+import { Button } from "@/components/ui/button"
+import { Badge } from "@/components/ui/badge"
+import { Plus } from "lucide-react"
+import { SortableTaskCard } from "./SortableTaskCard"
+import { TaskForm } from "./TaskForm"
 
 const columns = [
   { status: "pending", label: "À faire" },
   { status: "in_progress", label: "En cours" },
-  { status: "completed", label: "Terminée" },
   { status: "blocked", label: "Bloquée" },
+  { status: "completed", label: "Terminée" },
 ]
 
-export function TaskKanban({ tasks }: { tasks: Task[] }) {
+interface TaskKanbanProps {
+  tasks: Task[]
+  projectId: string
+  onTaskUpdate: () => void
+}
+
+export function TaskKanban({ tasks, projectId, onTaskUpdate }: TaskKanbanProps) {
+  const supabase = createClient()
+  const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 8 } }))
+
+  const [columnTasks, setColumnTasks] = useState<Record<string, Task[]>>({})
+  const [createInColumn, setCreateInColumn] = useState<string | null>(null)
+  const [editTask, setEditTask] = useState<Task | null>(null)
+
+  useEffect(() => {
+    const byStatus: Record<string, Task[]> = {}
+    columns.forEach((c) => {
+      byStatus[c.status] = tasks.filter((t) => t.status === c.status)
+    })
+    setColumnTasks(byStatus)
+  }, [tasks])
+
+  const findColumn = (taskId: string) => {
+    return columns.find((c) => columnTasks[c.status]?.some((t) => t.id === taskId))?.status
+  }
+
+  const handleDragEnd = async (event: DragEndEvent) => {
+    const { active, over } = event
+    if (!over) return
+
+    const activeId = String(active.id)
+    const overId = String(over.id)
+
+    const activeColumn = findColumn(activeId)
+    let overColumn = columns.find((c) => c.status === overId)?.status
+
+    if (!overColumn) {
+      overColumn = findColumn(overId) || overId
+    }
+
+    if (!activeColumn || !overColumn) return
+
+    if (activeColumn === overColumn) {
+      const oldIndex = columnTasks[activeColumn].findIndex((t) => t.id === activeId)
+      const newIndex = columnTasks[activeColumn].findIndex((t) => t.id === overId)
+      if (oldIndex !== newIndex && newIndex !== -1) {
+        setColumnTasks((prev) => ({
+          ...prev,
+          [activeColumn]: arrayMove(prev[activeColumn], oldIndex, newIndex),
+        }))
+      }
+    } else {
+      const oldIndex = columnTasks[activeColumn].findIndex((t) => t.id === activeId)
+      const task = columnTasks[activeColumn][oldIndex]
+      setColumnTasks((prev) => {
+        const source = [...prev[activeColumn]]
+        source.splice(oldIndex, 1)
+        const dest = [...prev[overColumn]]
+        dest.splice(0, 0, { ...task, status: overColumn })
+        return { ...prev, [activeColumn]: source, [overColumn]: dest }
+      })
+      await supabase.from("tasks").update({ status: overColumn }).eq("id", activeId)
+      onTaskUpdate && onTaskUpdate()
+    }
+  }
+
+  const getStatusBadgeClass = (status: string) => {
+    switch (status) {
+      case "pending":
+        return "bg-gray-100 text-gray-800"
+      case "in_progress":
+        return "bg-blue-100 text-blue-800"
+      case "completed":
+        return "bg-green-100 text-green-800"
+      case "blocked":
+        return "bg-red-100 text-red-800"
+      default:
+        return "bg-gray-100 text-gray-800"
+    }
+  }
+
+  const getPriorityBadgeClass = (priority: string) => {
+    switch (priority) {
+      case "low":
+        return "bg-green-100 text-green-800"
+      case "medium":
+        return "bg-yellow-100 text-yellow-800"
+      case "high":
+        return "bg-red-100 text-red-800"
+      default:
+        return "bg-gray-100 text-gray-800"
+    }
+  }
+
+  const isOverdue = (dueDate: string | null | undefined) => {
+    if (!dueDate) return false
+    const today = new Date()
+    today.setHours(0, 0, 0, 0)
+    const taskDueDate = new Date(dueDate)
+    return taskDueDate < today
+  }
+
   return (
-    <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
-      {columns.map((col) => {
-        const colTasks = tasks.filter((t) => t.status === col.status)
-        return (
-          <div key={col.status} className="border rounded-md p-2 bg-background">
-            <h4 className="font-semibold mb-2">{col.label}</h4>
-            <div className="space-y-2 min-h-[50px]">
-              {colTasks.length === 0 ? (
-                <p className="text-sm text-muted-foreground">Aucune tâche</p>
-              ) : (
-                colTasks.map((task) => (
-                  <div key={task.id} className="p-2 bg-muted rounded-md">
-                    {task.name}
-                  </div>
-                ))
-              )}
+    <DndContext sensors={sensors} collisionDetection={closestCorners} onDragEnd={handleDragEnd}>
+      <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
+        {columns.map((col) => {
+          const tasksForCol = columnTasks[col.status] || []
+          return (
+            <div key={col.status} className="border rounded-md p-2 bg-background flex flex-col">
+              <div className="flex items-center justify-between mb-2">
+                <h4 className="font-semibold">{col.label}</h4>
+                <Dialog open={createInColumn === col.status} onOpenChange={(o) => !o && setCreateInColumn(null)}>
+                  <DialogTrigger asChild>
+                    <Button variant="ghost" size="sm" onClick={() => setCreateInColumn(col.status)}>
+                      <Plus className="h-4 w-4" />
+                    </Button>
+                  </DialogTrigger>
+                  <DialogContent>
+                    <DialogHeader>
+                      <DialogTitle>Ajouter une tâche</DialogTitle>
+                    </DialogHeader>
+                    <TaskForm
+                      projectId={projectId}
+                      task={null}
+                      defaultStatus={col.status}
+                      onSuccess={() => {
+                        setCreateInColumn(null)
+                        onTaskUpdate && onTaskUpdate()
+                      }}
+                    />
+                  </DialogContent>
+                </Dialog>
+              </div>
+              <SortableContext items={tasksForCol.map((t) => t.id)} strategy={verticalListSortingStrategy} id={col.status}>
+                <div className="space-y-2 min-h-[50px] flex-1">
+                  {tasksForCol.length === 0 ? (
+                    <p className="text-sm text-muted-foreground">Aucune tâche</p>
+                  ) : (
+                    tasksForCol.map((task) => (
+                      <SortableTaskCard
+                        key={task.id}
+                        task={task}
+                        getPriorityBadgeClass={getPriorityBadgeClass}
+                        getStatusBadgeClass={getStatusBadgeClass}
+                        isOverdue={isOverdue}
+                        onClick={() => setEditTask(task)}
+                      />
+                    ))
+                  )}
+                </div>
+              </SortableContext>
             </div>
-          </div>
-        )
-      })}
-    </div>
+          )
+        })}
+      </div>
+
+      <Dialog open={!!editTask} onOpenChange={(o) => !o && setEditTask(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Modifier la tâche</DialogTitle>
+          </DialogHeader>
+          {editTask && (
+            <TaskForm
+              projectId={projectId}
+              task={editTask}
+              onSuccess={() => {
+                setEditTask(null)
+                onTaskUpdate && onTaskUpdate()
+              }}
+            />
+          )}
+        </DialogContent>
+      </Dialog>
+    </DndContext>
   )
 }


### PR DESCRIPTION
## Summary
- extend `useTaskForm` with optional default status
- update `TaskForm` to accept `defaultStatus`
- create `SortableTaskCard` for dnd items
- rebuild `TaskKanban` with drag & drop, add/edit dialogs and backend status update
- wire Kanban view in project details

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: cannot find type declarations)*
- `npm test` *(fails: jest not found)*