### PR TITLE
Implement category lazy loading in product form

### DIFF
--- a/features/product/shared/ui/ProductForm.tsx
+++ b/features/product/shared/ui/ProductForm.tsx
@@ -14,7 +14,7 @@ import { ProductFormView } from "@/features/product/shared/ui/ProductFormView"
 export function ProductForm({ product }: { product: Product | null }) {
   const router = useRouter()
   const [isCategoryModalOpen, setIsCategoryModalOpen] = useState(false)
-  const { categories, isLoading: isLoadingCategories } = useCategories()
+  const { categories, isLoading: isLoadingCategories, fetchCategories } = useCategories()
 
   const {
     form,
@@ -48,6 +48,7 @@ export function ProductForm({ product }: { product: Product | null }) {
         error={error}
         categories={categories}
         isLoadingCategories={isLoadingCategories}
+        loadCategories={fetchCategories}
         onSubmit={onSubmit}
         onOpenCategoryModal={() => setIsCategoryModalOpen(true)}
       />

--- a/features/product/shared/ui/ProductFormView.tsx
+++ b/features/product/shared/ui/ProductFormView.tsx
@@ -23,6 +23,7 @@ interface ProductFormViewProps {
   error: string | null
   categories: { id: string; name: string; color?: string }[]
   isLoadingCategories: boolean
+  loadCategories: () => void
   onSubmit: (values: ProductFormSchema) => void
   onOpenCategoryModal: () => void
 }
@@ -33,6 +34,7 @@ export const ProductFormView: React.FC<ProductFormViewProps> = ({
   error,
   categories,
   isLoadingCategories,
+  loadCategories,
   onSubmit,
   onOpenCategoryModal,
 }) => (
@@ -95,6 +97,11 @@ export const ProductFormView: React.FC<ProductFormViewProps> = ({
               <Select
                 value={field.value ?? ""}
                 onValueChange={(value) => field.onChange(value === "none" ? null : value)}
+                onOpenChange={(open) => {
+                  if (open) {
+                    loadCategories()
+                  }
+                }}
               >
                 <FormControl>
                   <SelectTrigger className="w-full">

--- a/shared/hooks/use-categories.ts
+++ b/shared/hooks/use-categories.ts
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, useEffect } from "react"
+import { useState } from "react"
 import { createClient } from "@/shared/lib/supabase/client"
 
 export function useCategories() {
@@ -8,9 +8,31 @@ export function useCategories() {
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
+  const supabase = createClient()
+
+  const fetchCategories = async () => {
+    setIsLoading(true)
+    setError(null)
+    try {
+      const { data, error } = await supabase
+        .from("product_categories")
+        .select("*")
+        .order("name", { ascending: true })
+
+      if (error) throw error
+
+      setCategories(data || [])
+    } catch (err: any) {
+      setError(err.message)
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
   return {
     categories,
     isLoading,
     error,
+    fetchCategories,
   }
 }


### PR DESCRIPTION
## Summary
- add fetch logic to `useCategories` hook
- support lazy loading categories in `ProductFormView`
- wire lazy fetch in `ProductForm`

## Testing
- `npm test` *(fails: jest not found)*