### PR TITLE
Add client invoices view

### DIFF
--- a/app/dashboard/clients/[id]/page.tsx
+++ b/app/dashboard/clients/[id]/page.tsx
@@ -1,9 +1,12 @@
 import { getClientAction } from "@/features/client/shared/actions/getClient.action"
 import { ClientForm } from "@/features/client/shared/ui/ClientForm"
+import { getInvoicesByClientAction } from "@/features/invoice/list/actions/getInvoicesByClient.action"
+import { InvoicesTable } from "@/features/invoice/list/ui/InvoicesTable"
 import FormPageLayout from "@/shared/ui/FormPageLayout"
 
 export default async function EditClientPage({ params, }: { params: { id: string } }) {
   const result = await getClientAction(params.id)
+  const invoicesResult = await getInvoicesByClientAction(params.id)
 
   if (!result.success) {
     return <div>{result.error}</div>
@@ -16,6 +19,7 @@ export default async function EditClientPage({ params, }: { params: { id: string
       backHref="/dashboard/clients"
     >
       <ClientForm client={result.data} />
+      {invoicesResult.success && <InvoicesTable invoices={invoicesResult.data} />}
     </FormPageLayout>
   )
 }

--- a/features/client/list/ui/ClientsTable.tsx
+++ b/features/client/list/ui/ClientsTable.tsx
@@ -3,7 +3,7 @@
 import { useClientsTable } from "@/features/client/list/hooks/useClientsTable"
 import { Client } from "@/features/client/shared/types/client.types"
 import { DataTable } from "@/components/ui/data-table"
-import { Edit, Package, Trash } from "lucide-react"
+import { Edit, Package, Trash, FileText } from "lucide-react"
 import Link from "next/link"
 
 export function ClientsTable({ clients }: { clients: Client[] }) {
@@ -33,6 +33,11 @@ export function ClientsTable({ clients }: { clients: Client[] }) {
     {
       label: "Modifier",
       icon: <Edit className="h-4 w-4" />,
+      onClick: (client: Client) => router.push(`/dashboard/clients/${client.id}`)
+    },
+    {
+      label: "Factures",
+      icon: <FileText className="h-4 w-4" />,
       onClick: (client: Client) => router.push(`/dashboard/clients/${client.id}`)
     },
     {

--- a/features/invoice/list/actions/getInvoicesByClient.action.ts
+++ b/features/invoice/list/actions/getInvoicesByClient.action.ts
@@ -1,0 +1,14 @@
+"use server"
+
+import { getInvoicesByClient } from '../model/getInvoicesByClient'
+import { Invoice } from '@/features/invoice/shared/types/invoice.types'
+import { fail, Result, success } from '@/shared/utils/result'
+
+export async function getInvoicesByClientAction(clientId: string): Promise<Result<Invoice[]>> {
+  try {
+    const invoices = await getInvoicesByClient(clientId)
+    return success(invoices)
+  } catch (error) {
+    return fail((error as Error).message)
+  }
+}

--- a/features/invoice/list/model/getInvoicesByClient.ts
+++ b/features/invoice/list/model/getInvoicesByClient.ts
@@ -1,0 +1,16 @@
+import { Invoice } from '@/features/invoice/shared/types/invoice.types'
+import { getSessionUser } from '@/shared/utils/getSessionUser'
+import { extractDataOrThrow } from '@/shared/utils/extractDataOrThrow'
+
+export async function getInvoicesByClient(clientId: string): Promise<Invoice[]> {
+  const { supabase, user } = await getSessionUser()
+
+  const res = await supabase
+    .from('invoices')
+    .select('*, client:client_id(name)')
+    .eq('user_id', user.id)
+    .eq('client_id', clientId)
+    .order('created_at', { ascending: false })
+
+  return extractDataOrThrow<Invoice[]>(res)
+}


### PR DESCRIPTION
## Summary
- fetch invoices by client in new model & action
- show client invoices on the client edit page
- add link to view invoices from the clients table

## Testing
- `npm test` *(fails: jest not found)*