### PR TITLE
Add withAction helper and refactor actions

### DIFF
--- a/features/category/create/actions/createCategory.action.ts
+++ b/features/category/create/actions/createCategory.action.ts
@@ -4,15 +4,15 @@ import { CategoryFormData } from '@/features/category/shared/types/category.type
 import { createCategory } from '@/features/category/create/model/createCategory'
 import { revalidatePath } from "next/cache"
 import { redirect } from "next/navigation"
-import { fail, Result } from '@/shared/utils/result'
+import { Result } from '@/shared/utils/result'
+import { withAction } from '@/shared/utils/withAction'
 
 export async function createCategoryAction(data: CategoryFormData): Promise<Result<null>> {
-  try {
+  return withAction(async () => {
     await createCategory(data)
     revalidatePath("/dashboard/products/categories")
     revalidatePath("/dashboard/products")
     redirect("/dashboard/products/categories")
-  } catch (error) {
-    return fail((error as Error).message)
-  }
+    return null
+  })
 }

--- a/features/category/delete/actions/deleteCategory.action.ts
+++ b/features/category/delete/actions/deleteCategory.action.ts
@@ -2,15 +2,14 @@
 
 import { deleteCategory } from '@/features/category/delete/model/deleteCategory'
 import { revalidatePath } from "next/cache"
-import { fail, Result, success } from '@/shared/utils/result'
+import { Result } from '@/shared/utils/result'
+import { withAction } from '@/shared/utils/withAction'
 
 export async function deleteCategoryAction(categoryId: string): Promise<Result<null>> {
-  try {
+  return withAction(async () => {
     await deleteCategory(categoryId)
     revalidatePath("/dashboard/products/categories")
     revalidatePath("/dashboard/products")
-    return success(null)
-  } catch (error) {
-    return fail((error as Error).message)
-  }
+    return null
+  })
 }

--- a/features/category/edit/actions/updateCategory.action.ts
+++ b/features/category/edit/actions/updateCategory.action.ts
@@ -2,7 +2,8 @@
 
 import { updateCategory } from '@/features/category/edit/model/updateCategory'
 import { CategoryFormData } from '@/features/category/shared/types/category.types'
-import { fail, Result } from '@/shared/utils/result'
+import { Result } from '@/shared/utils/result'
+import { withAction } from '@/shared/utils/withAction'
 import { revalidatePath } from "next/cache"
 import { redirect } from "next/navigation"
 
@@ -10,12 +11,11 @@ export async function updateCategoryAction(
   categoryId: string,
   data: CategoryFormData
 ): Promise<Result<null>> {
-  try {
+  return withAction(async () => {
     await updateCategory(categoryId, data)
     revalidatePath("/dashboard/products/categories")
     revalidatePath("/dashboard/products")
     redirect("/dashboard/products/categories")
-  } catch (error) {
-    return fail((error as Error).message)
-  }
+    return null
+  })
 }

--- a/features/category/list/actions/getCategories.action.ts
+++ b/features/category/list/actions/getCategories.action.ts
@@ -2,14 +2,13 @@
 
 import { getCategories } from '@/features/category/list/model/getCategories'
 import { Category } from '@/features/category/shared/types/category.types'
-import { fail, Result, success } from '@/shared/utils/result'
+import { Result } from '@/shared/utils/result'
+import { withAction } from '@/shared/utils/withAction'
 
 export async function getCategoriesAction(): Promise<Result<Category[]>> {
-  try {
+  return withAction(async () => {
     const categories = await getCategories()
-    return success(categories)
-  } catch (error) {
-    return fail((error as Error).message)
-  }
+    return categories
+  })
 }
 

--- a/features/category/shared/actions/getCategory.action.ts
+++ b/features/category/shared/actions/getCategory.action.ts
@@ -1,14 +1,13 @@
 'use server'
 
-import { fail, Result, success } from '@/shared/utils/result'
+import { Result } from '@/shared/utils/result'
+import { withAction } from '@/shared/utils/withAction'
 import { getCategory } from '@/features/category/shared/model/getCategory'
 import { Category } from '@/features/category/shared/types/category.types'
 
 export async function getCategoryAction(categoryId: string): Promise<Result<Category>> {
-  try {
+  return withAction(async () => {
     const category = await getCategory(categoryId)
-    return success(category)
-  } catch (error) {
-    return fail((error as Error).message)
-  }
-} 
+    return category
+  })
+}

--- a/features/client/create/actions/createClient.action.ts
+++ b/features/client/create/actions/createClient.action.ts
@@ -2,14 +2,12 @@
 import { revalidatePath } from "next/cache";
 import { ClientFormSchema } from '@/features/client/shared/schema/client.schema';
 import { createClient } from '@/features/client/create/model/createClient';
-import { fail, Result, success } from '@/shared/utils/result'
+import { Result } from '@/shared/utils/result'
+import { withAction } from '@/shared/utils/withAction'
 
 export async function createClientAction(formData: ClientFormSchema): Promise<Result<null>> {
-  try {
+  return withAction(async () => {
     await createClient(formData);
-    revalidatePath("/dashboard/clients")
-    return success(null)
-  } catch (error) {
-    return fail((error as Error).message)
-  }
-} 
+    return null
+  }, { revalidatePath: '/dashboard/clients' })
+}

--- a/features/client/create/actions/createClientInline.action.ts
+++ b/features/client/create/actions/createClientInline.action.ts
@@ -3,14 +3,13 @@
 import { revalidatePath } from "next/cache"
 import { Client, ClientFormData } from "@/features/client/shared/types/client.types"
 import { createClient } from "@/features/client/create/model/createClient"
-import { Result, fail, success } from "@/shared/utils/result"
+import { Result } from "@/shared/utils/result"
+import { withAction } from "@/shared/utils/withAction"
 
 export async function createClientInlineAction(data: ClientFormData): Promise<Result<Client>> {
-  try {
+  return withAction(async () => {
     const client = await createClient(data)
     revalidatePath("/dashboard/clients")
-    return success(client as Client)
-  } catch (error) {
-    return fail((error as Error).message)
-  }
+    return client as Client
+  })
 }

--- a/features/client/delete/actions/deleteClient.action.ts
+++ b/features/client/delete/actions/deleteClient.action.ts
@@ -1,14 +1,12 @@
 "use server"
 import { revalidatePath } from "next/cache";
 import { deleteClient } from '@/features/client/delete/model/deleteClient';
-import { fail, Result, success } from "@/shared/utils/result";
+import { Result } from "@/shared/utils/result";
+import { withAction } from "@/shared/utils/withAction";
 
 export async function deleteClientAction(clientId: string): Promise<Result<void>> {
-  try {
+  return withAction(async () => {
     await deleteClient(clientId);
-    revalidatePath("/dashboard/clients");
-    return success(undefined);
-  } catch (error) {
-    return fail((error as Error).message);
-  }
-} 
+    return undefined;
+  }, { revalidatePath: '/dashboard/clients' });
+}

--- a/features/client/edit/actions/updateClient.action.ts
+++ b/features/client/edit/actions/updateClient.action.ts
@@ -2,14 +2,12 @@
 import { revalidatePath } from "next/cache";
 import { ClientFormData } from '@/features/client/shared/types/client.types';
 import { updateClient } from '@/features/client/edit/model/updateClient';
-import { fail, Result, success } from "@/shared/utils/result";
+import { Result } from "@/shared/utils/result";
+import { withAction } from "@/shared/utils/withAction";
 
 export async function updateClientAction(clientId: string, data: ClientFormData): Promise<Result<null>> {
-  try {
+  return withAction(async () => {
     await updateClient(clientId, data);
-    revalidatePath("/dashboard/clients");
-    return success(null);
-  } catch (error) {
-    return fail((error as Error).message);
-  }
-} 
+    return null;
+  }, { revalidatePath: '/dashboard/clients' });
+}

--- a/features/client/list/actions/getClients.action.ts
+++ b/features/client/list/actions/getClients.action.ts
@@ -2,13 +2,12 @@
 
 import { Client } from '@/features/client/shared/types/client.types'
 import { getClients } from '@/features/client/list/model/getClients'
-import { fail, Result, success } from '@/shared/utils/result'
+import { Result } from '@/shared/utils/result'
+import { withAction } from '@/shared/utils/withAction'
 
 export async function getClientsAction(): Promise<Result<Client[]>> {
-  try {
+  return withAction(async () => {
     const clients = await getClients()
-    return success(clients)
-  } catch (error) {
-    return fail((error as Error).message)
-  }
+    return clients
+  })
 }

--- a/features/client/shared/actions/getClient.action.ts
+++ b/features/client/shared/actions/getClient.action.ts
@@ -1,13 +1,12 @@
 "use server"
 import { Client } from '@/features/client/shared/types/client.types';
 import { getClient } from '@/features/client/shared/model/getClient';
-import { fail, Result, success } from '@/shared/utils/result';
+import { Result } from '@/shared/utils/result';
+import { withAction } from '@/shared/utils/withAction';
 
 export async function getClientAction(clientId: string): Promise<Result<Client>> {
-  try {
+  return withAction(async () => {
     const client = await getClient(clientId);
-    return success(client);
-  } catch (error) {
-    return fail((error as Error).message);
-  }
-} 
+    return client;
+  });
+}

--- a/features/invoice/create/actions/createInvoice.action.ts
+++ b/features/invoice/create/actions/createInvoice.action.ts
@@ -3,17 +3,13 @@
 import { createInvoice } from '@/features/invoice/create/model/createInvoice'
 import { createInvoiceItems } from '@/features/invoice/create/model/createInvoiceItems'
 import { Invoice, InvoiceItem } from '@/features/invoice/shared/types/invoice.types'
-import { fail, Result, success } from '@/shared/utils/result'
-import { revalidatePath } from 'next/cache'
-import { redirect } from 'next/navigation'
+import { Result } from '@/shared/utils/result'
+import { withAction } from '@/shared/utils/withAction'
 
 export async function createInvoiceAction(formData: Invoice, items: InvoiceItem[]): Promise<Result<null>> {
-  try {
+  return withAction(async () => {
     const invoiceId = await createInvoice(formData)
     await createInvoiceItems(invoiceId, items, formData.tax_rate)
-    revalidatePath('/dashboard/invoices')
-    return success(null)
-  } catch (error) {
-    return fail((error as Error).message)
-  }
+    return null
+  }, { revalidatePath: '/dashboard/invoices' })
 }

--- a/features/invoice/delete/actions/deleteInvoice.action.ts
+++ b/features/invoice/delete/actions/deleteInvoice.action.ts
@@ -1,17 +1,12 @@
 'use server'
 
 import { deleteInvoice } from '@/features/invoice/delete/model/deleteInvoice'
-import { Invoice } from '@/features/invoice/shared/types/invoice.types'
-import { revalidatePath } from 'next/cache'
-import { redirect } from 'next/navigation'
-import { fail, Result } from '@/shared/utils/result'
+import { Result } from '@/shared/utils/result'
+import { withAction } from '@/shared/utils/withAction'
 
-export async function deleteInvoiceAction(invoiceId: string): Promise<Result<Invoice>> {
-  try {
+export async function deleteInvoiceAction(invoiceId: string): Promise<Result<null>> {
+  return withAction(async () => {
     await deleteInvoice(invoiceId)
-    revalidatePath('/dashboard/invoices')
-    redirect('/dashboard/invoices')
-  } catch (err: any) {
-    return fail((err as Error).message)
-  }
+    return null
+  }, { revalidatePath: '/dashboard/invoices', redirect: '/dashboard/invoices' })
 }

--- a/features/invoice/edit/actions/updateInvoice.action.ts
+++ b/features/invoice/edit/actions/updateInvoice.action.ts
@@ -3,9 +3,8 @@ import { Invoice, InvoiceItem } from '@/features/invoice/shared/types/invoice.ty
 import { updateInvoice } from '@/features/invoice/edit/model/updateInvoice'
 import { deleteRemovedInvoiceItems } from '@/features/invoice/edit/model/deleteRemovedInvoiceItems'
 import { upsertInvoiceItems } from '@/features/invoice/edit/model/upsertInvoiceItems'
-import { revalidatePath } from "next/cache"
-import { redirect } from "next/navigation"
-import { fail, Result } from '@/shared/utils/result'
+import { Result } from '@/shared/utils/result'
+import { withAction } from '@/shared/utils/withAction'
 
 export async function updateInvoiceAction(
   invoiceId: string,
@@ -13,13 +12,10 @@ export async function updateInvoiceAction(
   items: InvoiceItem[],
   originalItems: InvoiceItem[] = []
 ): Promise<Result<null>> {
-  try {
+  return withAction(async () => {
     await updateInvoice(invoiceId, formData)
     await deleteRemovedInvoiceItems(items, originalItems)
     await upsertInvoiceItems(invoiceId, items, formData.tax_rate)
-    revalidatePath("/dashboard/invoices")
-    redirect(`/dashboard/invoices/${invoiceId}`)
-  } catch (error) {
-    return fail((error as Error).message)
-  }
+    return null
+  }, { revalidatePath: '/dashboard/invoices', redirect: `/dashboard/invoices/${invoiceId}` })
 }

--- a/features/invoice/email/actions/sendInvoiceEmail.action.ts
+++ b/features/invoice/email/actions/sendInvoiceEmail.action.ts
@@ -2,13 +2,14 @@
 
 import { getInvoice } from '@/features/invoice/view/model/getInvoice'
 import { generateInvoicePdf } from '@/features/invoice/pdf/model/generateInvoicePdf'
-import { Result, success, fail } from '@/shared/utils/result'
+import { Result } from '@/shared/utils/result'
+import { withAction } from '@/shared/utils/withAction'
 import { Resend } from 'resend'
 
 const resend = new Resend(process.env.RESEND_API_KEY)
 
 export async function sendInvoiceEmailAction(invoiceId: string, recipientEmail: string): Promise<Result<null>> {
-  try {
+  return withAction(async () => {
     const invoice = await getInvoice(invoiceId)
     const { buffer } = await generateInvoicePdf(invoiceId)
 
@@ -25,8 +26,6 @@ export async function sendInvoiceEmailAction(invoiceId: string, recipientEmail: 
       ],
     })
 
-    return success(null)
-  } catch (error) {
-    return fail((error as Error).message)
-  }
+    return null
+  })
 }

--- a/features/invoice/list/actions/getInvoices.action.ts
+++ b/features/invoice/list/actions/getInvoices.action.ts
@@ -2,13 +2,12 @@
 
 import { getInvoices } from '../model/getInvoices'
 import { Invoice } from '@/features/invoice/shared/types/invoice.types'
-import { fail, Result, success } from '@/shared/utils/result'
+import { Result } from '@/shared/utils/result'
+import { withAction } from '@/shared/utils/withAction'
 
 export async function getInvoicesAction(): Promise<Result<Invoice[]>> {
-  try {
+  return withAction(async () => {
     const invoices = await getInvoices()
-    return success(invoices)
-  } catch (error) {
-    return fail((error as Error).message)
-  }
+    return invoices
+  })
 }

--- a/features/invoice/list/actions/getInvoicesByClient.action.ts
+++ b/features/invoice/list/actions/getInvoicesByClient.action.ts
@@ -2,13 +2,12 @@
 
 import { getInvoicesByClient } from '../model/getInvoicesByClient'
 import { Invoice } from '@/features/invoice/shared/types/invoice.types'
-import { fail, Result, success } from '@/shared/utils/result'
+import { Result } from '@/shared/utils/result'
+import { withAction } from '@/shared/utils/withAction'
 
 export async function getInvoicesByClientAction(clientId: string): Promise<Result<Invoice[]>> {
-  try {
+  return withAction(async () => {
     const invoices = await getInvoicesByClient(clientId)
-    return success(invoices)
-  } catch (error) {
-    return fail((error as Error).message)
-  }
+    return invoices
+  })
 }

--- a/features/invoice/shared/actions/getInvoice.action.ts
+++ b/features/invoice/shared/actions/getInvoice.action.ts
@@ -5,20 +5,16 @@ import { getInvoiceItems } from "@/features/invoice/view/model/getInvoiceItems"
 import { getClientsList } from "@/features/invoice/view/model/getClients"
 import { getDefaultCurrency } from "@/features/invoice/view/model/getDefaultCurrency"
 import { Result } from "@/shared/utils/result"
+import { withAction } from "@/shared/utils/withAction"
 import { InvoiceDetailsProps } from "@/features/invoice/shared/types/invoice.types"
 
 export async function getInvoiceAction(invoiceId: string): Promise<Result<InvoiceDetailsProps>> {
-  try {
+  return withAction(async () => {
     const invoice = await getInvoice(invoiceId)
     const invoiceItems = await getInvoiceItems(invoiceId)
     const clients = await getClientsList()
     const defaultCurrency = await getDefaultCurrency()
 
-    return {
-      success: true,
-      data: { invoice, invoiceItems, clients, defaultCurrency }
-    }
-  } catch (error) {
-    return { success: false, error: (error as Error).message }
-  }
+    return { invoice, invoiceItems, clients, defaultCurrency }
+  })
 }

--- a/features/invoice/shared/actions/updateInvoiceStatus.action.ts
+++ b/features/invoice/shared/actions/updateInvoiceStatus.action.ts
@@ -2,18 +2,16 @@
 
 import { revalidatePath } from 'next/cache'
 import { updateInvoiceStatus } from '@/features/invoice/shared/model/updateInvoiceStatus'
-import { fail, Result, success } from '@/shared/utils/result'
+import { Result } from '@/shared/utils/result'
+import { withAction } from '@/shared/utils/withAction'
 import { Invoice } from '@/features/invoice/shared/types/invoice.types'
 
 export async function updateInvoiceStatusAction(
   invoiceId: string,
   status: string
 ): Promise<Result<Invoice>> {
-  try {
+  return withAction(async () => {
     const invoice = await updateInvoiceStatus(invoiceId, status)
-    revalidatePath('/dashboard/invoices')
-    return success(invoice)
-  } catch (error) {
-    return fail((error as Error).message)
-  }
+    return invoice
+  }, { revalidatePath: '/dashboard/invoices' })
 }

--- a/features/notification/create/actions/createNotification.action.ts
+++ b/features/notification/create/actions/createNotification.action.ts
@@ -2,15 +2,14 @@
 
 import { createNotification } from '@/features/notification/create/model/createNotification'
 import { NotificationFormData, DbNotification } from '@/features/notification/shared/types/notification.types'
-import { fail, Result, success } from '@/shared/utils/result'
+import { Result } from '@/shared/utils/result'
+import { withAction } from '@/shared/utils/withAction'
 
 export async function createNotificationAction(
   data: NotificationFormData,
 ): Promise<Result<DbNotification>> {
-  try {
+  return withAction(async () => {
     const notification = await createNotification(data)
-    return success(notification)
-  } catch (error) {
-    return fail((error as Error).message)
-  }
+    return notification
+  })
 }

--- a/features/notification/delete/actions/deleteNotification.action.ts
+++ b/features/notification/delete/actions/deleteNotification.action.ts
@@ -2,13 +2,12 @@
 
 import { deleteNotification } from '@/features/notification/delete/model/deleteNotification'
 import { DbNotification } from '@/features/notification/shared/types/notification.types'
-import { fail, Result, success } from '@/shared/utils/result'
+import { Result } from '@/shared/utils/result'
+import { withAction } from '@/shared/utils/withAction'
 
 export async function deleteNotificationAction(id: string): Promise<Result<DbNotification>> {
-  try {
+  return withAction(async () => {
     const notification = await deleteNotification(id)
-    return success(notification)
-  } catch (error) {
-    return fail((error as Error).message)
-  }
+    return notification
+  })
 }

--- a/features/notification/edit/actions/markAllRead.action.ts
+++ b/features/notification/edit/actions/markAllRead.action.ts
@@ -1,13 +1,12 @@
 'use server'
 
 import { markAllNotificationsRead } from '@/features/notification/edit/model/markAllRead'
-import { fail, Result, success } from '@/shared/utils/result'
+import { Result } from '@/shared/utils/result'
+import { withAction } from '@/shared/utils/withAction'
 
 export async function markAllNotificationsReadAction(): Promise<Result<null>> {
-  try {
+  return withAction(async () => {
     await markAllNotificationsRead()
-    return success(null)
-  } catch (error) {
-    return fail((error as Error).message)
-  }
+    return null
+  })
 }

--- a/features/notification/edit/actions/updateNotification.action.ts
+++ b/features/notification/edit/actions/updateNotification.action.ts
@@ -2,16 +2,15 @@
 
 import { updateNotification } from '@/features/notification/edit/model/updateNotification'
 import { DbNotification } from '@/features/notification/shared/types/notification.types'
-import { fail, Result, success } from '@/shared/utils/result'
+import { Result } from '@/shared/utils/result'
+import { withAction } from '@/shared/utils/withAction'
 
 export async function updateNotificationAction(
   id: string,
   data: Partial<DbNotification>,
 ): Promise<Result<DbNotification>> {
-  try {
+  return withAction(async () => {
     const notification = await updateNotification(id, data)
-    return success(notification)
-  } catch (error) {
-    return fail((error as Error).message)
-  }
+    return notification
+  })
 }

--- a/features/notification/list/actions/getNotifications.action.ts
+++ b/features/notification/list/actions/getNotifications.action.ts
@@ -2,13 +2,12 @@
 
 import { getNotifications } from '@/features/notification/list/model/getNotifications'
 import { DbNotification } from '@/features/notification/shared/types/notification.types'
-import { fail, Result, success } from '@/shared/utils/result'
+import { Result } from '@/shared/utils/result'
+import { withAction } from '@/shared/utils/withAction'
 
 export async function getNotificationsAction(): Promise<Result<DbNotification[]>> {
-  try {
+  return withAction(async () => {
     const notifications = await getNotifications()
-    return success(notifications)
-  } catch (error) {
-    return fail((error as Error).message)
-  }
+    return notifications
+  })
 }

--- a/features/payment/create/actions/createPayment.action.ts
+++ b/features/payment/create/actions/createPayment.action.ts
@@ -6,10 +6,11 @@ import { PaymentFormData } from '@/features/payment/shared/types/payment.types'
 import { createPayment } from '@/features/payment/create/model/createPayment'
 import { getSessionUser } from '@/shared/utils/getSessionUser'
 import { extractDataOrThrow } from '@/shared/utils/extractDataOrThrow'
-import { fail, Result, success } from '@/shared/utils/result'
+import { Result } from '@/shared/utils/result'
+import { withAction } from '@/shared/utils/withAction'
 
 export async function createPaymentAction(formData: PaymentFormData): Promise<Result<{ url: string | null }>> {
-  try {
+  return withAction(async () => {
     if (formData.payment_method === 'stripe') {
       const { supabase, user } = await getSessionUser()
 
@@ -44,13 +45,11 @@ export async function createPaymentAction(formData: PaymentFormData): Promise<Re
         cancel_url: `${process.env.NEXT_PUBLIC_SITE_URL}/dashboard/payments`,
       })
 
-      return success({ url: session.url })
+      return { url: session.url }
     }
 
     await createPayment(formData)
     revalidatePath('/dashboard/payments')
-    return success({ url: null })
-  } catch (error) {
-    return fail((error as Error).message)
-  }
+    return { url: null }
+  })
 }

--- a/features/payment/delete/actions/deletePayment.action.ts
+++ b/features/payment/delete/actions/deletePayment.action.ts
@@ -1,17 +1,13 @@
 'use server'
 
 import { deletePayment } from '@/features/payment/delete/model/deletePayment'
-import { fail } from '@/shared/utils/result'
-import { success } from '@/shared/utils/result'
 import { Result } from '@/shared/utils/result'
+import { withAction } from '@/shared/utils/withAction'
 import { revalidatePath } from 'next/cache'
 
 export async function deletePaymentAction(paymentId: string): Promise<Result<null>> {
-  try {
+  return withAction(async () => {
     await deletePayment(paymentId)
-    revalidatePath("/dashboard/payments")
-    return success(null)
-  } catch (error) {
-    return fail((error as Error).message)
-  }
+    return null
+  }, { revalidatePath: '/dashboard/payments' })
 }

--- a/features/payment/delete/actions/deletePaymentAndUpdateInvoice.action.ts
+++ b/features/payment/delete/actions/deletePaymentAndUpdateInvoice.action.ts
@@ -2,15 +2,14 @@
 
 import { deletePayment } from '@/features/payment/delete/model/deletePayment'
 import { revalidatePath } from 'next/cache'
-import { fail, Result, success } from '@/shared/utils/result'
+import { Result } from '@/shared/utils/result'
+import { withAction } from '@/shared/utils/withAction'
 
 export async function deletePaymentAndUpdateInvoiceAction(paymentId: string): Promise<Result<null>> {
-  try {
+  return withAction(async () => {
     await deletePayment(paymentId)
     revalidatePath('/dashboard/payments')
     revalidatePath('/dashboard/invoices')
-    return success(null)
-  } catch (error) {
-    return fail((error as Error).message)
-  }
+    return null
+  })
 }

--- a/features/payment/edit/actions/updatePayment.action.ts
+++ b/features/payment/edit/actions/updatePayment.action.ts
@@ -3,17 +3,15 @@
 import { revalidatePath } from 'next/cache'
 import { updatePayment } from '@/features/payment/edit/model/updatePayment'
 import { PaymentFormData } from '@/features/payment/shared/types/payment.types'
-import { fail, Result, success } from '@/shared/utils/result'
+import { Result } from '@/shared/utils/result'
+import { withAction } from '@/shared/utils/withAction'
 
 export async function updatePaymentAction(
   paymentId: string,
   formData: PaymentFormData
 ): Promise<Result<null>> {
-  try {
+  return withAction(async () => {
     await updatePayment(paymentId, formData)
-    revalidatePath("/dashboard/payments")
-    return success(null)
-  } catch (error) {
-    return fail((error as Error).message)
-  }
+    return null
+  }, { revalidatePath: '/dashboard/payments' })
 }

--- a/features/payment/list/actions/getPayments.action.ts
+++ b/features/payment/list/actions/getPayments.action.ts
@@ -1,14 +1,13 @@
 'use server'
 
-import { fail, success, Result } from '@/shared/utils/result'
+import { Result } from '@/shared/utils/result'
+import { withAction } from '@/shared/utils/withAction'
 import { getPayments } from '../model/getPayments'
 import { Payment } from '@/features/payment/shared/types/payment.types'
 
 export async function getPaymentsAction(): Promise<Result<Payment[]>> {
-  try {
+  return withAction(async () => {
     const payments = await getPayments()
-    return success(payments)
-  } catch (error) {
-    return fail((error as Error).message)
-  }
+    return payments
+  })
 }

--- a/features/payment/shared/actions/getPayment.action.ts
+++ b/features/payment/shared/actions/getPayment.action.ts
@@ -1,14 +1,13 @@
 'use server'
 
-import { success, fail, Result } from '@/shared/utils/result'
+import { Result } from '@/shared/utils/result'
+import { withAction } from '@/shared/utils/withAction'
 import { getPayment } from '@/features/payment/shared/model/getPayment'
 import { Payment } from '@/features/payment/shared/types/payment.types'
 
 export async function getPaymentAction(paymentId: string): Promise<Result<Payment>> {
-  try {
+  return withAction(async () => {
     const payment = await getPayment(paymentId)
-    return success(payment)
-  } catch (error) {
-    return fail((error as Error).message)
-  }
+    return payment
+  })
 }

--- a/features/product/create/actions/createProduct.action.ts
+++ b/features/product/create/actions/createProduct.action.ts
@@ -2,16 +2,13 @@
 
 import { createProduct } from '@/features/product/create/model/createProduct'
 import { Product } from '@/features/product/shared/types/product.types'
-import { fail, Result } from '@/shared/utils/result'
-import { success } from '@/shared/utils/result'
+import { Result } from '@/shared/utils/result'
+import { withAction } from '@/shared/utils/withAction'
 import { revalidatePath } from "next/cache"
 
 export async function createProductAction(formData: Product): Promise<Result<null>> {
-  try {
+  return withAction(async () => {
     await createProduct(formData)
-    revalidatePath("/dashboard/products")
-    return success(null)
-  } catch (error) {
-    return fail((error as Error).message)
-  }
+    return null
+  }, { revalidatePath: '/dashboard/products' })
 }

--- a/features/product/edit/actions/updateProduct.action.ts
+++ b/features/product/edit/actions/updateProduct.action.ts
@@ -2,20 +2,18 @@
 
 import { updateProduct } from '@/features/product/edit/model/updateProduct'
 import { Product } from '@/features/product/shared/types/product.types'
-import { fail, Result } from '@/shared/utils/result'
-import { success } from '@/shared/utils/result'
+import { Result } from '@/shared/utils/result'
+import { withAction } from '@/shared/utils/withAction'
 import { revalidatePath } from "next/cache"
 
 export async function updateProductAction(
   productId: string,
   formData: Product
 ): Promise<Result<null>> {
-  try {
+  return withAction(async () => {
     await updateProduct(productId, formData)
     revalidatePath("/dashboard/products")
     revalidatePath(`/dashboard/products/${productId}`)
-    return success(null)
-  } catch (error) {
-    return fail((error as Error).message)
-  }
+    return null
+  })
 }

--- a/features/product/list/actions/getProducts.action.ts
+++ b/features/product/list/actions/getProducts.action.ts
@@ -2,13 +2,12 @@
 
 import { getProducts } from '@/features/product/list/model/getProducts'
 import { Product } from '@/features/product/shared/types/product.types'
-import { fail, Result, success } from '@/shared/utils/result'
+import { Result } from '@/shared/utils/result'
+import { withAction } from '@/shared/utils/withAction'
 
 export async function getProductsAction(): Promise<Result<Product[]>> {
-  try {
+  return withAction(async () => {
     const products = await getProducts()
-    return success(products)
-  } catch (error) {
-    return fail((error as Error).message)
-  }
+    return products
+  })
 }

--- a/features/product/shared/actions/deleteProduct.action.ts
+++ b/features/product/shared/actions/deleteProduct.action.ts
@@ -1,16 +1,13 @@
 'use server'
 
 import { deleteProduct } from '@/features/product/delete/model/deleteProduct'
-import { fail, Result } from '@/shared/utils/result'
-import { success } from '@/shared/utils/result'
+import { Result } from '@/shared/utils/result'
+import { withAction } from '@/shared/utils/withAction'
 import { revalidatePath } from "next/cache"
 
 export async function deleteProductAction(productId: string): Promise<Result<null>> {
-  try {
-     await deleteProduct(productId)
-    revalidatePath("/dashboard/products")
-    return success(null)
-  } catch (error) {
-    return fail((error as Error).message)
-  }
+  return withAction(async () => {
+    await deleteProduct(productId)
+    return null
+  }, { revalidatePath: '/dashboard/products' })
 }

--- a/features/product/shared/actions/getProduct.action.ts
+++ b/features/product/shared/actions/getProduct.action.ts
@@ -2,14 +2,12 @@
 
 import { getProduct } from "@/features/product/shared/model/getProduct"
 import { Product } from '@/features/product/shared/types/product.types'
-import { fail, Result } from "@/shared/utils/result"
-import { success } from "@/shared/utils/result"
+import { Result } from "@/shared/utils/result"
+import { withAction } from "@/shared/utils/withAction"
 
 export async function getProductAction(productId: string): Promise<Result<Product>> {
-  try {
+  return withAction(async () => {
     const product = await getProduct(productId)
-    return success(product)
-  } catch (error) {
-    return fail((error as Error).message)
-  }
+    return product
+  })
 }

--- a/features/project/create/actions/createProject.action.ts
+++ b/features/project/create/actions/createProject.action.ts
@@ -2,14 +2,12 @@
 
 import { createProject } from '@/features/project/create/model/createProject'
 import { Project, ProjectFormData } from '@/features/project/shared/types/project.types'
-import { fail, Result } from '@/shared/utils/result'
-import { success } from '@/shared/utils/result'
+import { Result } from '@/shared/utils/result'
+import { withAction } from '@/shared/utils/withAction'
 
 export async function createProjectAction(formData: ProjectFormData): Promise<Result<Project>> {
-  try {
+  return withAction(async () => {
     const project = await createProject(formData)
-    return success(project)
-  } catch (error) {
-    return fail((error as Error).message)
-  }
+    return project
+  })
 }

--- a/features/project/delete/actions/deleteProject.action.ts
+++ b/features/project/delete/actions/deleteProject.action.ts
@@ -1,16 +1,13 @@
 'use server'
 
 import { deleteProject } from '@/features/project/delete/model/deleteProject'
-import { fail, Result } from '@/shared/utils/result'
-import { success } from '@/shared/utils/result'
+import { Result } from '@/shared/utils/result'
+import { withAction } from '@/shared/utils/withAction'
 import { revalidatePath } from 'next/cache'
 
 export async function deleteProjectAction(projectId: string): Promise<Result<null>> {
-  try {
+  return withAction(async () => {
     await deleteProject(projectId)
-    revalidatePath('/dashboard/projects')
-    return success(null)
-  } catch (error) {
-    return fail((error as Error).message)
-  }
+    return null
+  }, { revalidatePath: '/dashboard/projects' })
 }

--- a/features/project/edit/actions/updateProject.action.ts
+++ b/features/project/edit/actions/updateProject.action.ts
@@ -2,17 +2,15 @@
 
 import { updateProject } from "@/features/project/edit/model/updateProject"
 import { ProjectFormData } from '@/features/project/shared/types/project.types'
-import { fail, Result } from "@/shared/utils/result"
-import { success } from "@/shared/utils/result"
+import { Result } from "@/shared/utils/result"
+import { withAction } from "@/shared/utils/withAction"
 
 export async function updateProjectAction(
   projectId: string,
   formData: ProjectFormData
 ): Promise<Result<null>> {
-  try {
+  return withAction(async () => {
     await updateProject(projectId, formData)
-    return success(null)
-  } catch (error) {
-    return fail((error as Error).message)
-  }
+    return null
+  })
 }

--- a/features/project/list/actions/getProjects.action.ts
+++ b/features/project/list/actions/getProjects.action.ts
@@ -3,14 +3,11 @@
 import { getProjects } from '@/features/project/list/model/getProjects'
 import { Project} from '@/features/project/shared/types/project.types'
 import { Result } from '@/shared/utils/result'
-import { fail } from '@/shared/utils/result'
-import { success } from '@/shared/utils/result'
+import { withAction } from '@/shared/utils/withAction'
 
 export async function getProjectsAction(): Promise<Result<Project[]>> {
-    try {
+    return withAction(async () => {
         const projects = await getProjects()
-        return success(projects)
-    } catch (error) {
-        return fail((error as Error).message)
-    }
+        return projects
+    })
 }

--- a/features/project/shared/actions/getProject.action.ts
+++ b/features/project/shared/actions/getProject.action.ts
@@ -2,13 +2,12 @@
 
 import { getProjectDetails } from '@/features/project/edit/model/getProjectDetails'
 import { Project } from '@/features/project/shared/types/project.types'
-import { fail, Result, success } from '@/shared/utils/result'
+import { Result } from '@/shared/utils/result'
+import { withAction } from '@/shared/utils/withAction'
 
 export async function getProjectAction(projectId: string): Promise<Result<Project>> {
-  try {
+  return withAction(async () => {
     const project = await getProjectDetails(projectId)
-    return success(project)
-  } catch (error) {
-    return fail((error as Error).message)
-  }
+    return project
+  })
 }

--- a/features/project/view/actions/getProject.action.ts
+++ b/features/project/view/actions/getProject.action.ts
@@ -2,13 +2,12 @@
 
 import { getProjectDetails } from '@/features/project/view/model/getProjectDetails'
 import { Project } from '@/features/project/shared/types/project.types'
-import { fail, Result, success } from '@/shared/utils/result'
+import { Result } from '@/shared/utils/result'
+import { withAction } from '@/shared/utils/withAction'
 
 export async function getProjectAction(projectId: string): Promise<Result<Project>> {
-  try {
+  return withAction(async () => {
     const project = await getProjectDetails(projectId)
-    return success(project)
-  } catch (error) {
-    return fail((error as Error).message)
-  }
-} 
+    return project
+  })
+}

--- a/features/setting/actions/deleteLogo.action.ts
+++ b/features/setting/actions/deleteLogo.action.ts
@@ -1,15 +1,13 @@
 'use server'
 
 import { deleteLogo } from "@/features/setting/model/deleteLogo"
-import { fail, Result, success } from "@/shared/utils/result"
+import { Result } from "@/shared/utils/result"
+import { withAction } from "@/shared/utils/withAction"
 import { revalidatePath } from 'next/cache'
 
 export async function deleteLogoAction(): Promise<Result<null>> {
-  try {
+  return withAction(async () => {
     await deleteLogo()
-    revalidatePath('/dashboard/profile')
-    return success(null)
-  } catch (error) {
-    return fail((error as Error).message)
-  }
+    return null
+  }, { revalidatePath: '/dashboard/profile' })
 }

--- a/features/setting/actions/getUserProfile.action.ts
+++ b/features/setting/actions/getUserProfile.action.ts
@@ -2,13 +2,12 @@
 
 import { getUserProfile } from '@/features/setting/model/getUserProfile'
 import { UserProfile } from '@/features/setting/types/profile.types'
-import { fail, Result, success } from '@/shared/utils/result'
+import { Result } from '@/shared/utils/result'
+import { withAction } from '@/shared/utils/withAction'
 
 export async function getUserProfileAction(): Promise<Result<UserProfile>> {
-  try {
+  return withAction(async () => {
     const profile = await getUserProfile()
-    return success(profile)
-  } catch (error) {
-    return fail((error as Error).message)
-  }
+    return profile
+  })
 }

--- a/features/setting/actions/updateUserProfile.action.ts
+++ b/features/setting/actions/updateUserProfile.action.ts
@@ -4,7 +4,8 @@ import { updateUserProfile } from "@/features/setting/model/updateUserProfile"
 import { UserProfileFormData } from '@/features/setting/types/profile.types'
 import { profileFormSchema } from '@/features/setting/schema/profile.schema'
 import { revalidatePath } from 'next/cache'
-import { fail, Result, success } from "@/shared/utils/result"
+import { Result, fail } from "@/shared/utils/result"
+import { withAction } from "@/shared/utils/withAction"
 import { safeParseForm } from '@/shared/utils/safeParseForm'
 
 export async function updateUserProfileAction(form: FormData): Promise<Result<null>> {
@@ -15,11 +16,8 @@ export async function updateUserProfileAction(form: FormData): Promise<Result<nu
     return fail(errorMessage)
   }
 
-  try {
+  return withAction(async () => {
     await updateUserProfile(parsed.data as UserProfileFormData)
-    revalidatePath('/dashboard/profile')
-    return success(null)
-  } catch (error) {
-    return fail((error as Error).message)
-  }
+    return null
+  }, { revalidatePath: '/dashboard/profile' })
 }

--- a/features/setting/actions/uploadLogo.action.ts
+++ b/features/setting/actions/uploadLogo.action.ts
@@ -1,16 +1,14 @@
 'use server'
 
 import { uploadLogo } from "@/features/setting/model/uploadLogo"
-import { fail, Result, success } from "@/shared/utils/result"
+import { Result } from "@/shared/utils/result"
+import { withAction } from "@/shared/utils/withAction"
 import { revalidatePath } from 'next/cache'
 
 export async function uploadLogoAction(formData: FormData): Promise<Result<string>> {
-  try {
+  return withAction(async () => {
     const logoFile = formData.get("logo") as File
     const publicUrl = await uploadLogo(logoFile)
-    revalidatePath("/dashboard/profile")
-    return success(publicUrl)
-  } catch (error) {
-    return fail((error as Error).message)
-  }
+    return publicUrl
+  }, { revalidatePath: '/dashboard/profile' })
 }

--- a/features/task/create/actions/createTask.action.ts
+++ b/features/task/create/actions/createTask.action.ts
@@ -3,14 +3,13 @@
 import { createTask } from "@/features/task/create/model/createTask"
 import { Task, TaskFormData } from '@/features/task/shared/types/task.types'
 import { revalidatePath } from 'next/cache'
-import { fail, Result, success } from '@/shared/utils/result'
+import { Result } from '@/shared/utils/result'
+import { withAction } from '@/shared/utils/withAction'
 
 export async function createTaskAction(projectId: string, formData: TaskFormData): Promise<Result<Task>> {
-  try {
+  return withAction(async () => {
     const task = await createTask(projectId, formData)
     revalidatePath(`/dashboard/projects/${projectId}`)
-    return success(task)
-  } catch (error) {
-    return fail((error as Error).message)
-  }
+    return task
+  })
 }

--- a/features/time-tracking/create/actions/createTimeEntry.action.ts
+++ b/features/time-tracking/create/actions/createTimeEntry.action.ts
@@ -4,16 +4,14 @@ import { revalidatePath } from 'next/cache'
 import { redirect } from 'next/navigation'
 import { createTimeEntry } from '@/features/time-tracking/create/model/createTimeEntry'
 import { TimeEntryFormData, TimeEntry } from '@/features/time-tracking/shared/types/timeEntry.types'
-import { Result, fail } from '@/shared/utils/result'
+import { Result } from '@/shared/utils/result'
+import { withAction } from '@/shared/utils/withAction'
 
 export async function createTimeEntryAction(
   formData: TimeEntryFormData,
 ): Promise<Result<TimeEntry>> {
-  try {
+  return withAction(async () => {
     const entry = await createTimeEntry(formData)
-    revalidatePath('/dashboard/time-tracking')
-    redirect('/dashboard/time-tracking')
-  } catch (error) {
-    return fail((error as Error).message)
-  }
+    return entry
+  }, { revalidatePath: '/dashboard/time-tracking', redirect: '/dashboard/time-tracking' })
 }

--- a/features/time-tracking/edit/actions/updateTimeEntry.action.ts
+++ b/features/time-tracking/edit/actions/updateTimeEntry.action.ts
@@ -3,17 +3,15 @@
 import { revalidatePath } from 'next/cache'
 import { updateTimeEntry } from '@/features/time-tracking/edit/model/updateTimeEntry'
 import { TimeEntryFormData } from '@/features/time-tracking/shared/types/timeEntry.types'
-import { Result, fail, success } from '@/shared/utils/result'
+import { Result } from '@/shared/utils/result'
+import { withAction } from '@/shared/utils/withAction'
 
 export async function updateTimeEntryAction(
   entryId: string,
   formData: TimeEntryFormData,
 ): Promise<Result<null>> {
-  try {
+  return withAction(async () => {
     await updateTimeEntry(entryId, formData)
-    revalidatePath('/dashboard/time-tracking')
-    return success(null)
-  } catch (error) {
-    return fail((error as Error).message)
-  }
+    return null
+  }, { revalidatePath: '/dashboard/time-tracking' })
 }

--- a/features/time-tracking/list/actions/deleteTimeEntry.action.ts
+++ b/features/time-tracking/list/actions/deleteTimeEntry.action.ts
@@ -1,15 +1,13 @@
 'use server'
 
 import { deleteTimeEntry } from '../model/deleteTimeEntry'
-import { Result, success, fail } from '@/shared/utils/result'
+import { Result } from '@/shared/utils/result'
+import { withAction } from '@/shared/utils/withAction'
 import { revalidatePath } from 'next/cache'
 
 export async function deleteTimeEntryAction(entryId: string): Promise<Result<null>> {
-  try {
+  return withAction(async () => {
     await deleteTimeEntry(entryId)
-    revalidatePath('/dashboard/time-tracking')
-    return success(null)
-  } catch (error) {
-    return fail((error as Error).message)
-  }
+    return null
+  }, { revalidatePath: '/dashboard/time-tracking' })
 }

--- a/features/time-tracking/list/actions/getTimeEntries.action.ts
+++ b/features/time-tracking/list/actions/getTimeEntries.action.ts
@@ -2,13 +2,12 @@
 
 import { getTimeEntries } from '../model/getTimeEntries'
 import { TimeEntry } from '@/features/time-tracking/shared/types/timeEntry.types'
-import { Result, success, fail } from '@/shared/utils/result'
+import { Result } from '@/shared/utils/result'
+import { withAction } from '@/shared/utils/withAction'
 
 export async function getTimeEntriesAction(): Promise<Result<TimeEntry[]>> {
-  try {
+  return withAction(async () => {
     const entries = await getTimeEntries()
-    return success(entries)
-  } catch (error) {
-    return fail((error as Error).message)
-  }
+    return entries
+  })
 }

--- a/features/time-tracking/shared/actions/getTimeEntry.action.ts
+++ b/features/time-tracking/shared/actions/getTimeEntry.action.ts
@@ -2,13 +2,12 @@
 
 import { getTimeEntry } from '../model/getTimeEntry'
 import { TimeEntry } from '@/features/time-tracking/shared/types/timeEntry.types'
-import { Result, success, fail } from '@/shared/utils/result'
+import { Result } from '@/shared/utils/result'
+import { withAction } from '@/shared/utils/withAction'
 
 export async function getTimeEntryAction(entryId: string): Promise<Result<TimeEntry>> {
-  try {
+  return withAction(async () => {
     const entry = await getTimeEntry(entryId)
-    return success(entry)
-  } catch (error) {
-    return fail((error as Error).message)
-  }
+    return entry
+  })
 }

--- a/shared/utils/withAction.ts
+++ b/shared/utils/withAction.ts
@@ -1,0 +1,31 @@
+import { revalidatePath as revalidate, } from 'next/cache'
+import { redirect as nextRedirect } from 'next/navigation'
+import { Result, success, fail } from '@/shared/utils/result'
+
+interface ActionOptions {
+  revalidatePath?: string | string[]
+  redirect?: string
+}
+
+export async function withAction<T>(
+  callback: () => Promise<T>,
+  options: ActionOptions = {},
+): Promise<Result<T>> {
+  try {
+    const data = await callback()
+    if (options.revalidatePath) {
+      const paths = Array.isArray(options.revalidatePath)
+        ? options.revalidatePath
+        : [options.revalidatePath]
+      for (const path of paths) {
+        revalidate(path)
+      }
+    }
+    if (options.redirect) {
+      nextRedirect(options.redirect)
+    }
+    return success(data)
+  } catch (error) {
+    return fail((error as Error).message)
+  }
+}


### PR DESCRIPTION
## Summary
- add `withAction` utility to unify action error handling
- refactor many server actions to use `withAction`

## Testing
- `npm test` *(fails: jest not found)*