### PR TITLE
Refactor actions to use shared routes

### DIFF
--- a/features/auth/register/actions/registerUser.action.ts
+++ b/features/auth/register/actions/registerUser.action.ts
@@ -3,6 +3,7 @@
 import { signUpWithEmail } from '@/shared/services/auth'
 import { RegisterSchema, registerSchema } from '@/features/auth/shared/schema/auth.schema'
 import { revalidatePath } from 'next/cache'
+import { DASHBOARD_PATH } from '@/shared/lib/routes'
 import { safeParseForm } from '@/shared/utils/safeParseForm'
 import type { FormResult } from '@/shared/types/api.types'
 
@@ -16,6 +17,6 @@ export async function registerUserAction(formData: FormData): Promise<FormResult
   const { error } = await signUpWithEmail(email, password, full_name)
   if (error) return { success: false, error }
 
-  revalidatePath('/dashboard')
+  revalidatePath(DASHBOARD_PATH)
   return { success: true, data: parsed.data }
 }

--- a/features/category/create/actions/createCategory.action.ts
+++ b/features/category/create/actions/createCategory.action.ts
@@ -4,14 +4,15 @@ import { CategoryFormData } from '@/features/category/shared/types/category.type
 import { createCategory } from '@/features/category/create/model/createCategory'
 import { revalidatePath } from "next/cache"
 import { redirect } from "next/navigation"
+import { PRODUCT_CATEGORIES_PATH, PRODUCTS_PATH } from '@/shared/lib/routes'
 import { fail, Result } from '@/shared/utils/result'
 
 export async function createCategoryAction(data: CategoryFormData): Promise<Result<null>> {
   try {
     await createCategory(data)
-    revalidatePath("/dashboard/products/categories")
-    revalidatePath("/dashboard/products")
-    redirect("/dashboard/products/categories")
+    revalidatePath(PRODUCT_CATEGORIES_PATH)
+    revalidatePath(PRODUCTS_PATH)
+    redirect(PRODUCT_CATEGORIES_PATH)
   } catch (error) {
     return fail((error as Error).message)
   }

--- a/features/category/delete/actions/deleteCategory.action.ts
+++ b/features/category/delete/actions/deleteCategory.action.ts
@@ -2,13 +2,14 @@
 
 import { deleteCategory } from '@/features/category/delete/model/deleteCategory'
 import { revalidatePath } from "next/cache"
+import { PRODUCT_CATEGORIES_PATH, PRODUCTS_PATH } from '@/shared/lib/routes'
 import { fail, Result, success } from '@/shared/utils/result'
 
 export async function deleteCategoryAction(categoryId: string): Promise<Result<null>> {
   try {
     await deleteCategory(categoryId)
-    revalidatePath("/dashboard/products/categories")
-    revalidatePath("/dashboard/products")
+    revalidatePath(PRODUCT_CATEGORIES_PATH)
+    revalidatePath(PRODUCTS_PATH)
     return success(null)
   } catch (error) {
     return fail((error as Error).message)

--- a/features/category/edit/actions/updateCategory.action.ts
+++ b/features/category/edit/actions/updateCategory.action.ts
@@ -5,6 +5,7 @@ import { CategoryFormData } from '@/features/category/shared/types/category.type
 import { fail, Result } from '@/shared/utils/result'
 import { revalidatePath } from "next/cache"
 import { redirect } from "next/navigation"
+import { PRODUCT_CATEGORIES_PATH, PRODUCTS_PATH } from '@/shared/lib/routes'
 
 export async function updateCategoryAction(
   categoryId: string,
@@ -12,9 +13,9 @@ export async function updateCategoryAction(
 ): Promise<Result<null>> {
   try {
     await updateCategory(categoryId, data)
-    revalidatePath("/dashboard/products/categories")
-    revalidatePath("/dashboard/products")
-    redirect("/dashboard/products/categories")
+    revalidatePath(PRODUCT_CATEGORIES_PATH)
+    revalidatePath(PRODUCTS_PATH)
+    redirect(PRODUCT_CATEGORIES_PATH)
   } catch (error) {
     return fail((error as Error).message)
   }

--- a/features/client/create/actions/createClient.action.ts
+++ b/features/client/create/actions/createClient.action.ts
@@ -1,5 +1,6 @@
 "use server"
 import { revalidatePath } from "next/cache";
+import { CLIENTS_PATH } from '@/shared/lib/routes'
 import { ClientFormSchema } from '@/features/client/shared/schema/client.schema';
 import { createClient } from '@/features/client/create/model/createClient';
 import { fail, Result, success } from '@/shared/utils/result'
@@ -7,7 +8,7 @@ import { fail, Result, success } from '@/shared/utils/result'
 export async function createClientAction(formData: ClientFormSchema): Promise<Result<null>> {
   try {
     await createClient(formData);
-    revalidatePath("/dashboard/clients")
+    revalidatePath(CLIENTS_PATH)
     return success(null)
   } catch (error) {
     return fail((error as Error).message)

--- a/features/client/create/actions/createClientInline.action.ts
+++ b/features/client/create/actions/createClientInline.action.ts
@@ -1,6 +1,7 @@
 "use server"
 
 import { revalidatePath } from "next/cache"
+import { CLIENTS_PATH } from '@/shared/lib/routes'
 import { Client, ClientFormData } from "@/features/client/shared/types/client.types"
 import { createClient } from "@/features/client/create/model/createClient"
 import { Result, fail, success } from "@/shared/utils/result"
@@ -8,7 +9,7 @@ import { Result, fail, success } from "@/shared/utils/result"
 export async function createClientInlineAction(data: ClientFormData): Promise<Result<Client>> {
   try {
     const client = await createClient(data)
-    revalidatePath("/dashboard/clients")
+    revalidatePath(CLIENTS_PATH)
     return success(client as Client)
   } catch (error) {
     return fail((error as Error).message)

--- a/features/client/delete/actions/deleteClient.action.ts
+++ b/features/client/delete/actions/deleteClient.action.ts
@@ -1,12 +1,13 @@
 "use server"
 import { revalidatePath } from "next/cache";
+import { CLIENTS_PATH } from '@/shared/lib/routes'
 import { deleteClient } from '@/features/client/delete/model/deleteClient';
 import { fail, Result, success } from "@/shared/utils/result";
 
 export async function deleteClientAction(clientId: string): Promise<Result<void>> {
   try {
     await deleteClient(clientId);
-    revalidatePath("/dashboard/clients");
+    revalidatePath(CLIENTS_PATH);
     return success(undefined);
   } catch (error) {
     return fail((error as Error).message);

--- a/features/client/edit/actions/updateClient.action.ts
+++ b/features/client/edit/actions/updateClient.action.ts
@@ -1,5 +1,6 @@
 "use server"
 import { revalidatePath } from "next/cache";
+import { CLIENTS_PATH } from '@/shared/lib/routes'
 import { ClientFormData } from '@/features/client/shared/types/client.types';
 import { updateClient } from '@/features/client/edit/model/updateClient';
 import { fail, Result, success } from "@/shared/utils/result";
@@ -7,7 +8,7 @@ import { fail, Result, success } from "@/shared/utils/result";
 export async function updateClientAction(clientId: string, data: ClientFormData): Promise<Result<null>> {
   try {
     await updateClient(clientId, data);
-    revalidatePath("/dashboard/clients");
+    revalidatePath(CLIENTS_PATH);
     return success(null);
   } catch (error) {
     return fail((error as Error).message);

--- a/features/invoice/create/actions/createInvoice.action.ts
+++ b/features/invoice/create/actions/createInvoice.action.ts
@@ -5,13 +5,13 @@ import { createInvoiceItems } from '@/features/invoice/create/model/createInvoic
 import { Invoice, InvoiceItem } from '@/features/invoice/shared/types/invoice.types'
 import { fail, Result, success } from '@/shared/utils/result'
 import { revalidatePath } from 'next/cache'
-import { redirect } from 'next/navigation'
+import { INVOICES_PATH } from '@/shared/lib/routes'
 
 export async function createInvoiceAction(formData: Invoice, items: InvoiceItem[]): Promise<Result<null>> {
   try {
     const invoiceId = await createInvoice(formData)
     await createInvoiceItems(invoiceId, items, formData.tax_rate)
-    revalidatePath('/dashboard/invoices')
+    revalidatePath(INVOICES_PATH)
     return success(null)
   } catch (error) {
     return fail((error as Error).message)

--- a/features/invoice/delete/actions/deleteInvoice.action.ts
+++ b/features/invoice/delete/actions/deleteInvoice.action.ts
@@ -4,13 +4,14 @@ import { deleteInvoice } from '@/features/invoice/delete/model/deleteInvoice'
 import { Invoice } from '@/features/invoice/shared/types/invoice.types'
 import { revalidatePath } from 'next/cache'
 import { redirect } from 'next/navigation'
+import { INVOICES_PATH } from '@/shared/lib/routes'
 import { fail, Result } from '@/shared/utils/result'
 
 export async function deleteInvoiceAction(invoiceId: string): Promise<Result<Invoice>> {
   try {
     await deleteInvoice(invoiceId)
-    revalidatePath('/dashboard/invoices')
-    redirect('/dashboard/invoices')
+    revalidatePath(INVOICES_PATH)
+    redirect(INVOICES_PATH)
   } catch (err: any) {
     return fail((err as Error).message)
   }

--- a/features/invoice/edit/actions/updateInvoice.action.ts
+++ b/features/invoice/edit/actions/updateInvoice.action.ts
@@ -5,6 +5,7 @@ import { deleteRemovedInvoiceItems } from '@/features/invoice/edit/model/deleteR
 import { upsertInvoiceItems } from '@/features/invoice/edit/model/upsertInvoiceItems'
 import { revalidatePath } from "next/cache"
 import { redirect } from "next/navigation"
+import { INVOICES_PATH, invoicePath } from '@/shared/lib/routes'
 import { fail, Result } from '@/shared/utils/result'
 
 export async function updateInvoiceAction(
@@ -17,8 +18,8 @@ export async function updateInvoiceAction(
     await updateInvoice(invoiceId, formData)
     await deleteRemovedInvoiceItems(items, originalItems)
     await upsertInvoiceItems(invoiceId, items, formData.tax_rate)
-    revalidatePath("/dashboard/invoices")
-    redirect(`/dashboard/invoices/${invoiceId}`)
+    revalidatePath(INVOICES_PATH)
+    redirect(invoicePath(invoiceId))
   } catch (error) {
     return fail((error as Error).message)
   }

--- a/features/invoice/shared/actions/updateInvoiceStatus.action.ts
+++ b/features/invoice/shared/actions/updateInvoiceStatus.action.ts
@@ -1,6 +1,7 @@
 'use server'
 
 import { revalidatePath } from 'next/cache'
+import { INVOICES_PATH } from '@/shared/lib/routes'
 import { updateInvoiceStatus } from '@/features/invoice/shared/model/updateInvoiceStatus'
 import { fail, Result, success } from '@/shared/utils/result'
 import { Invoice } from '@/features/invoice/shared/types/invoice.types'
@@ -11,7 +12,7 @@ export async function updateInvoiceStatusAction(
 ): Promise<Result<Invoice>> {
   try {
     const invoice = await updateInvoiceStatus(invoiceId, status)
-    revalidatePath('/dashboard/invoices')
+    revalidatePath(INVOICES_PATH)
     return success(invoice)
   } catch (error) {
     return fail((error as Error).message)

--- a/features/payment/create/actions/createPayment.action.ts
+++ b/features/payment/create/actions/createPayment.action.ts
@@ -1,6 +1,7 @@
 'use server'
 
 import { revalidatePath } from 'next/cache'
+import { PAYMENTS_PATH } from '@/shared/lib/routes'
 import Stripe from 'stripe'
 import { PaymentFormData } from '@/features/payment/shared/types/payment.types'
 import { createPayment } from '@/features/payment/create/model/createPayment'
@@ -48,7 +49,7 @@ export async function createPaymentAction(formData: PaymentFormData): Promise<Re
     }
 
     await createPayment(formData)
-    revalidatePath('/dashboard/payments')
+    revalidatePath(PAYMENTS_PATH)
     return success({ url: null })
   } catch (error) {
     return fail((error as Error).message)

--- a/features/payment/delete/actions/deletePayment.action.ts
+++ b/features/payment/delete/actions/deletePayment.action.ts
@@ -5,11 +5,12 @@ import { fail } from '@/shared/utils/result'
 import { success } from '@/shared/utils/result'
 import { Result } from '@/shared/utils/result'
 import { revalidatePath } from 'next/cache'
+import { PAYMENTS_PATH } from '@/shared/lib/routes'
 
 export async function deletePaymentAction(paymentId: string): Promise<Result<null>> {
   try {
     await deletePayment(paymentId)
-    revalidatePath("/dashboard/payments")
+    revalidatePath(PAYMENTS_PATH)
     return success(null)
   } catch (error) {
     return fail((error as Error).message)

--- a/features/payment/delete/actions/deletePaymentAndUpdateInvoice.action.ts
+++ b/features/payment/delete/actions/deletePaymentAndUpdateInvoice.action.ts
@@ -2,13 +2,14 @@
 
 import { deletePayment } from '@/features/payment/delete/model/deletePayment'
 import { revalidatePath } from 'next/cache'
+import { PAYMENTS_PATH, INVOICES_PATH } from '@/shared/lib/routes'
 import { fail, Result, success } from '@/shared/utils/result'
 
 export async function deletePaymentAndUpdateInvoiceAction(paymentId: string): Promise<Result<null>> {
   try {
     await deletePayment(paymentId)
-    revalidatePath('/dashboard/payments')
-    revalidatePath('/dashboard/invoices')
+    revalidatePath(PAYMENTS_PATH)
+    revalidatePath(INVOICES_PATH)
     return success(null)
   } catch (error) {
     return fail((error as Error).message)

--- a/features/payment/edit/actions/updatePayment.action.ts
+++ b/features/payment/edit/actions/updatePayment.action.ts
@@ -1,6 +1,7 @@
 'use server'
 
 import { revalidatePath } from 'next/cache'
+import { PAYMENTS_PATH } from '@/shared/lib/routes'
 import { updatePayment } from '@/features/payment/edit/model/updatePayment'
 import { PaymentFormData } from '@/features/payment/shared/types/payment.types'
 import { fail, Result, success } from '@/shared/utils/result'
@@ -11,7 +12,7 @@ export async function updatePaymentAction(
 ): Promise<Result<null>> {
   try {
     await updatePayment(paymentId, formData)
-    revalidatePath("/dashboard/payments")
+    revalidatePath(PAYMENTS_PATH)
     return success(null)
   } catch (error) {
     return fail((error as Error).message)

--- a/features/product/create/actions/createProduct.action.ts
+++ b/features/product/create/actions/createProduct.action.ts
@@ -5,11 +5,12 @@ import { Product } from '@/features/product/shared/types/product.types'
 import { fail, Result } from '@/shared/utils/result'
 import { success } from '@/shared/utils/result'
 import { revalidatePath } from "next/cache"
+import { PRODUCTS_PATH } from '@/shared/lib/routes'
 
 export async function createProductAction(formData: Product): Promise<Result<null>> {
   try {
     await createProduct(formData)
-    revalidatePath("/dashboard/products")
+    revalidatePath(PRODUCTS_PATH)
     return success(null)
   } catch (error) {
     return fail((error as Error).message)

--- a/features/product/edit/actions/updateProduct.action.ts
+++ b/features/product/edit/actions/updateProduct.action.ts
@@ -5,6 +5,7 @@ import { Product } from '@/features/product/shared/types/product.types'
 import { fail, Result } from '@/shared/utils/result'
 import { success } from '@/shared/utils/result'
 import { revalidatePath } from "next/cache"
+import { PRODUCTS_PATH, productPath } from '@/shared/lib/routes'
 
 export async function updateProductAction(
   productId: string,
@@ -12,8 +13,8 @@ export async function updateProductAction(
 ): Promise<Result<null>> {
   try {
     await updateProduct(productId, formData)
-    revalidatePath("/dashboard/products")
-    revalidatePath(`/dashboard/products/${productId}`)
+    revalidatePath(PRODUCTS_PATH)
+    revalidatePath(productPath(productId))
     return success(null)
   } catch (error) {
     return fail((error as Error).message)

--- a/features/product/shared/actions/deleteProduct.action.ts
+++ b/features/product/shared/actions/deleteProduct.action.ts
@@ -4,11 +4,12 @@ import { deleteProduct } from '@/features/product/delete/model/deleteProduct'
 import { fail, Result } from '@/shared/utils/result'
 import { success } from '@/shared/utils/result'
 import { revalidatePath } from "next/cache"
+import { PRODUCTS_PATH } from '@/shared/lib/routes'
 
 export async function deleteProductAction(productId: string): Promise<Result<null>> {
   try {
      await deleteProduct(productId)
-    revalidatePath("/dashboard/products")
+    revalidatePath(PRODUCTS_PATH)
     return success(null)
   } catch (error) {
     return fail((error as Error).message)

--- a/features/project/delete/actions/deleteProject.action.ts
+++ b/features/project/delete/actions/deleteProject.action.ts
@@ -4,11 +4,12 @@ import { deleteProject } from '@/features/project/delete/model/deleteProject'
 import { fail, Result } from '@/shared/utils/result'
 import { success } from '@/shared/utils/result'
 import { revalidatePath } from 'next/cache'
+import { PROJECTS_PATH } from '@/shared/lib/routes'
 
 export async function deleteProjectAction(projectId: string): Promise<Result<null>> {
   try {
     await deleteProject(projectId)
-    revalidatePath('/dashboard/projects')
+    revalidatePath(PROJECTS_PATH)
     return success(null)
   } catch (error) {
     return fail((error as Error).message)

--- a/features/setting/actions/deleteLogo.action.ts
+++ b/features/setting/actions/deleteLogo.action.ts
@@ -3,11 +3,12 @@
 import { deleteLogo } from "@/features/setting/model/deleteLogo"
 import { fail, Result, success } from "@/shared/utils/result"
 import { revalidatePath } from 'next/cache'
+import { PROFILE_PATH } from '@/shared/lib/routes'
 
 export async function deleteLogoAction(): Promise<Result<null>> {
   try {
     await deleteLogo()
-    revalidatePath('/dashboard/profile')
+    revalidatePath(PROFILE_PATH)
     return success(null)
   } catch (error) {
     return fail((error as Error).message)

--- a/features/setting/actions/updateUserProfile.action.ts
+++ b/features/setting/actions/updateUserProfile.action.ts
@@ -4,6 +4,7 @@ import { updateUserProfile } from "@/features/setting/model/updateUserProfile"
 import { UserProfileFormData } from '@/features/setting/types/profile.types'
 import { profileFormSchema } from '@/features/setting/schema/profile.schema'
 import { revalidatePath } from 'next/cache'
+import { PROFILE_PATH } from '@/shared/lib/routes'
 import { fail, Result, success } from "@/shared/utils/result"
 import { safeParseForm } from '@/shared/utils/safeParseForm'
 
@@ -17,7 +18,7 @@ export async function updateUserProfileAction(form: FormData): Promise<Result<nu
 
   try {
     await updateUserProfile(parsed.data as UserProfileFormData)
-    revalidatePath('/dashboard/profile')
+    revalidatePath(PROFILE_PATH)
     return success(null)
   } catch (error) {
     return fail((error as Error).message)

--- a/features/setting/actions/uploadLogo.action.ts
+++ b/features/setting/actions/uploadLogo.action.ts
@@ -3,12 +3,13 @@
 import { uploadLogo } from "@/features/setting/model/uploadLogo"
 import { fail, Result, success } from "@/shared/utils/result"
 import { revalidatePath } from 'next/cache'
+import { PROFILE_PATH } from '@/shared/lib/routes'
 
 export async function uploadLogoAction(formData: FormData): Promise<Result<string>> {
   try {
     const logoFile = formData.get("logo") as File
     const publicUrl = await uploadLogo(logoFile)
-    revalidatePath("/dashboard/profile")
+    revalidatePath(PROFILE_PATH)
     return success(publicUrl)
   } catch (error) {
     return fail((error as Error).message)

--- a/features/subtask/create/actions/createSubtask.action.ts
+++ b/features/subtask/create/actions/createSubtask.action.ts
@@ -4,11 +4,12 @@ import { createSubtask } from '@/features/subtask/create/model/createSubtask'
 import { Task, TaskFormData } from '@/features/task/shared/types/task.types'
 import { fail, Result, success } from '@/shared/utils/result'
 import { revalidatePath } from 'next/cache'
+import { projectPath } from '@/shared/lib/routes'
 
 export async function createSubtaskAction(taskId: string, formData: TaskFormData): Promise<Result<Task>> {
   try {
     const { subtask, projectId } = await createSubtask(taskId, formData)
-    revalidatePath(`/dashboard/projects/${projectId}`)
+    revalidatePath(projectPath(projectId))
     return success(subtask)
   } catch (error) {
     return fail((error as Error).message)

--- a/features/subtask/delete/actions/deleteSubtask.action.ts
+++ b/features/subtask/delete/actions/deleteSubtask.action.ts
@@ -3,11 +3,12 @@
 import { deleteSubtask } from '@/features/subtask/delete/model/deleteSubtask'
 import { TaskActionResult } from '@/features/task/shared/types/task.types'
 import { revalidatePath } from 'next/cache'
+import { projectPath } from '@/shared/lib/routes'
 
 export async function deleteSubtaskAction(subtaskId: string): Promise<TaskActionResult> {
   try {
     const { projectId } = await deleteSubtask(subtaskId)
-    revalidatePath(`/dashboard/projects/${projectId}`)
+    revalidatePath(projectPath(projectId))
     return { success: true }
   } catch (error) {
     return { success: false, error: (error as Error).message }

--- a/features/subtask/edit/actions/updateSubtask.action.ts
+++ b/features/subtask/edit/actions/updateSubtask.action.ts
@@ -3,11 +3,12 @@
 import { updateSubtask } from '@/features/subtask/edit/model/updateSubtask'
 import { TaskFormData, TaskActionResult } from '@/features/task/shared/types/task.types'
 import { revalidatePath } from 'next/cache'
+import { projectPath } from '@/shared/lib/routes'
 
 export async function updateSubtaskAction(subtaskId: string, formData: TaskFormData): Promise<TaskActionResult> {
   try {
     const { projectId } = await updateSubtask(subtaskId, formData)
-    revalidatePath(`/dashboard/projects/${projectId}`)
+    revalidatePath(projectPath(projectId))
     return { success: true }
   } catch (error) {
     return { success: false, error: (error as Error).message }

--- a/features/task/create/actions/createTask.action.ts
+++ b/features/task/create/actions/createTask.action.ts
@@ -3,12 +3,13 @@
 import { createTask } from "@/features/task/create/model/createTask"
 import { Task, TaskFormData } from '@/features/task/shared/types/task.types'
 import { revalidatePath } from 'next/cache'
+import { projectPath } from '@/shared/lib/routes'
 import { fail, Result, success } from '@/shared/utils/result'
 
 export async function createTaskAction(projectId: string, formData: TaskFormData): Promise<Result<Task>> {
   try {
     const task = await createTask(projectId, formData)
-    revalidatePath(`/dashboard/projects/${projectId}`)
+    revalidatePath(projectPath(projectId))
     return success(task)
   } catch (error) {
     return fail((error as Error).message)

--- a/features/task/delete/actions/deleteTask.action.ts
+++ b/features/task/delete/actions/deleteTask.action.ts
@@ -4,11 +4,12 @@
 import { deleteTask } from "@/features/task/delete/model/deleteTask"
 import { TaskActionResult } from '@/features/task/shared/types/task.types'
 import { revalidatePath } from 'next/cache'
+import { projectPath } from '@/shared/lib/routes'
 
 export async function deleteTaskAction(taskId: string): Promise<TaskActionResult> {
   try {
     const { projectId } = await deleteTask(taskId)
-    revalidatePath(`/dashboard/projects/${projectId}`)
+    revalidatePath(projectPath(projectId))
     return { success: true }
   } catch (error) {
     return { success: false, error: (error as Error).message }

--- a/features/task/edit/actions/updateTask.action.ts
+++ b/features/task/edit/actions/updateTask.action.ts
@@ -3,11 +3,12 @@
 import { updateTask } from "@/features/task/edit/model/updateTask"
 import { TaskFormData, TaskActionResult } from '@/features/task/shared/types/task.types'
 import { revalidatePath } from 'next/cache'
+import { projectPath } from '@/shared/lib/routes'
 
 export async function updateTaskAction(taskId: string, formData: TaskFormData): Promise<TaskActionResult> {
   try {
     const { projectId } = await updateTask(taskId, formData)
-    revalidatePath(`/dashboard/projects/${projectId}`)
+    revalidatePath(projectPath(projectId))
     return { success: true }
   } catch (error) {
     return { success: false, error: (error as Error).message }

--- a/features/time-tracking/create/actions/createTimeEntry.action.ts
+++ b/features/time-tracking/create/actions/createTimeEntry.action.ts
@@ -2,6 +2,7 @@
 
 import { revalidatePath } from 'next/cache'
 import { redirect } from 'next/navigation'
+import { TIME_TRACKING_PATH } from '@/shared/lib/routes'
 import { createTimeEntry } from '@/features/time-tracking/create/model/createTimeEntry'
 import { TimeEntryFormData, TimeEntry } from '@/features/time-tracking/shared/types/timeEntry.types'
 import { Result, fail } from '@/shared/utils/result'
@@ -11,8 +12,8 @@ export async function createTimeEntryAction(
 ): Promise<Result<TimeEntry>> {
   try {
     const entry = await createTimeEntry(formData)
-    revalidatePath('/dashboard/time-tracking')
-    redirect('/dashboard/time-tracking')
+    revalidatePath(TIME_TRACKING_PATH)
+    redirect(TIME_TRACKING_PATH)
   } catch (error) {
     return fail((error as Error).message)
   }

--- a/features/time-tracking/edit/actions/updateTimeEntry.action.ts
+++ b/features/time-tracking/edit/actions/updateTimeEntry.action.ts
@@ -1,6 +1,7 @@
 'use server'
 
 import { revalidatePath } from 'next/cache'
+import { TIME_TRACKING_PATH } from '@/shared/lib/routes'
 import { updateTimeEntry } from '@/features/time-tracking/edit/model/updateTimeEntry'
 import { TimeEntryFormData } from '@/features/time-tracking/shared/types/timeEntry.types'
 import { Result, fail, success } from '@/shared/utils/result'
@@ -11,7 +12,7 @@ export async function updateTimeEntryAction(
 ): Promise<Result<null>> {
   try {
     await updateTimeEntry(entryId, formData)
-    revalidatePath('/dashboard/time-tracking')
+    revalidatePath(TIME_TRACKING_PATH)
     return success(null)
   } catch (error) {
     return fail((error as Error).message)

--- a/features/time-tracking/list/actions/deleteTimeEntry.action.ts
+++ b/features/time-tracking/list/actions/deleteTimeEntry.action.ts
@@ -3,11 +3,12 @@
 import { deleteTimeEntry } from '../model/deleteTimeEntry'
 import { Result, success, fail } from '@/shared/utils/result'
 import { revalidatePath } from 'next/cache'
+import { TIME_TRACKING_PATH } from '@/shared/lib/routes'
 
 export async function deleteTimeEntryAction(entryId: string): Promise<Result<null>> {
   try {
     await deleteTimeEntry(entryId)
-    revalidatePath('/dashboard/time-tracking')
+    revalidatePath(TIME_TRACKING_PATH)
     return success(null)
   } catch (error) {
     return fail((error as Error).message)

--- a/shared/lib/routes.ts
+++ b/shared/lib/routes.ts
@@ -1,0 +1,12 @@
+export const DASHBOARD_PATH = '/dashboard'
+export const PROFILE_PATH = '/dashboard/profile'
+export const CLIENTS_PATH = '/dashboard/clients'
+export const TIME_TRACKING_PATH = '/dashboard/time-tracking'
+export const INVOICES_PATH = '/dashboard/invoices'
+export const invoicePath = (invoiceId: string) => `/dashboard/invoices/${invoiceId}`
+export const PROJECTS_PATH = '/dashboard/projects'
+export const projectPath = (projectId: string) => `/dashboard/projects/${projectId}`
+export const PRODUCTS_PATH = '/dashboard/products'
+export const productPath = (productId: string) => `/dashboard/products/${productId}`
+export const PRODUCT_CATEGORIES_PATH = '/dashboard/products/categories'
+export const PAYMENTS_PATH = '/dashboard/payments'


### PR DESCRIPTION
## Summary
- add `shared/lib/routes.ts` with dashboard path constants
- refactor feature actions to use shared routes for `revalidatePath` and `redirect`

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*