### PR TITLE
Add generic Supabase CRUD helpers

### DIFF
--- a/features/client/create/model/createClient.ts
+++ b/features/client/create/model/createClient.ts
@@ -1,7 +1,7 @@
 import { ClientFormSchema } from '@/features/client/shared/schema/client.schema';
 import { Client } from '@/features/client/shared/types/client.types';
 import { getSessionUser } from '@/shared/utils/getSessionUser'
-import { extractDataOrThrow } from '@/shared/utils/extractDataOrThrow'
+import { insertRecord } from '@/shared/services/supabase/crud'
 
 export async function createClient(formData: ClientFormSchema): Promise<Client> {
   const { supabase, user } = await getSessionUser() 
@@ -19,9 +19,5 @@ export async function createClient(formData: ClientFormSchema): Promise<Client> 
 
   finalData.user_id = user.id;
 
-  const res = await supabase.from("clients").insert(finalData).select("*").single()
-
-  if (res.error) throw new Error(res.error.message)
-
-  return extractDataOrThrow<Client>(res)
+  return await insertRecord<Client>(supabase, 'clients', finalData)
 }

--- a/features/invoice/view/model/getInvoice.ts
+++ b/features/invoice/view/model/getInvoice.ts
@@ -1,22 +1,19 @@
 import { Invoice } from '@/features/invoice/shared/types/invoice.types'
 import { getSessionUser } from '@/shared/utils/getSessionUser'
+import { fetchById } from '@/shared/services/supabase/crud'
 
 export async function getInvoice(invoiceId: string): Promise<Invoice> {
   const { supabase, user } = await getSessionUser()
 
-  const { data, error } = await supabase
-    .from('invoices')
-    .select(`
+  return await fetchById<Invoice>(
+    supabase,
+    'invoices',
+    invoiceId,
+    `
       *,
       payments:payments(*),
       client:client_id(name,email)
-    `)
-    .eq('id', invoiceId)
-    .eq('user_id', user.id)
-    .single()
-
-
-  if (error || !data) throw new Error('Facture non trouvée')
-
-  return data as Invoice
+    `,
+    { user_id: user.id }
+  )
 }

--- a/shared/services/supabase/crud.ts
+++ b/shared/services/supabase/crud.ts
@@ -1,0 +1,65 @@
+import type { SupabaseClient } from '@supabase/supabase-js'
+
+export async function fetchById<T>(
+  supabase: SupabaseClient,
+  table: string,
+  id: string,
+  select = '*',
+  filters: Record<string, any> = {}
+): Promise<T> {
+  let query: any = supabase.from(table).select(select).eq('id', id)
+  for (const [key, value] of Object.entries(filters)) {
+    query = query.eq(key, value as any)
+  }
+  const { data, error } = await query.single()
+  if (error) throw new Error(error.message)
+  return data as T
+}
+
+export async function insertRecord<T>(
+  supabase: SupabaseClient,
+  table: string,
+  values: Partial<T>,
+  select = '*'
+): Promise<T> {
+  const { data, error } = await supabase
+    .from(table)
+    .insert(values)
+    .select(select)
+    .single()
+  if (error) throw new Error(error.message)
+  return data as T
+}
+
+export async function updateRecord<T>(
+  supabase: SupabaseClient,
+  table: string,
+  id: string,
+  values: Partial<T>,
+  select = '*',
+  filters: Record<string, any> = {}
+): Promise<T> {
+  let query: any = supabase.from(table).update(values).eq('id', id)
+  for (const [key, value] of Object.entries(filters)) {
+    query = query.eq(key, value as any)
+  }
+  const { data, error } = await query.select(select).single()
+  if (error) throw new Error(error.message)
+  return data as T
+}
+
+export async function deleteRecord<T>(
+  supabase: SupabaseClient,
+  table: string,
+  id: string,
+  select = '*',
+  filters: Record<string, any> = {}
+): Promise<T> {
+  let query: any = supabase.from(table).delete().eq('id', id)
+  for (const [key, value] of Object.entries(filters)) {
+    query = query.eq(key, value as any)
+  }
+  const { data, error } = await query.select(select).single()
+  if (error) throw new Error(error.message)
+  return data as T
+}


### PR DESCRIPTION
## Summary
- create `shared/services/supabase/crud.ts`
- refactor `getInvoice` model to use `fetchById`
- refactor `createClient` model to use `insertRecord`

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*